### PR TITLE
Making it so that html generation doesn't blow up if you've symlinked front_end

### DIFF
--- a/static_html_generation/static_html_generator.py
+++ b/static_html_generation/static_html_generator.py
@@ -60,5 +60,6 @@ if __name__ == "__main__":
     write_file('/tmp/rege.html', markup)
     front_end_dir = '/tmp/front_end'
     if not path.islink(front_end_dir):
-        shutil.rmtree(front_end_dir)
+        if path.exists(front_end_dir):
+            shutil.rmtree(front_end_dir)
         shutil.copytree('../front_end', front_end_dir)


### PR DESCRIPTION
os.path.islink() returns False if the dir doesn't exist, doesn't throw an error.
