### PR TITLE
Display extra notice fields

### DIFF
--- a/static_html_generation/templates/notice.html
+++ b/static_html_generation/templates/notice.html
@@ -9,6 +9,33 @@
         <ul>
             <li>Document Number: {{ document_number }}</li>
             <li>CFR Part: {{ cfr_part }}</li>
+            <li>Agency: {{ agency }}</li>
+            <li>Action: {{ action }}</li>
+            <li>Summary: {{ summary }}</li>
+            <li>Contact: {{ contact }}</li>
+            {% if rin %}<li>RIN: {{ rin }}</li>{% endif %}
+            {% if dates %}
+            <li>Dates: 
+                <ul>
+                    {% for key, values in dates.items %}
+                    <li>{{ key | title }}: {{ values | join:", " }}</li>
+                    {% endfor %}
+                </ul>
+            </li>
+            {% endif %}
+            {% if addresses %}
+            <li>Addresses:<ul>
+                {% if addresses.intro %}<li>{{ addresses.intro }}</li>{% endif %}
+                {% for k,v in addresses.methods %}
+                    <li>{{ k }} : {{ v }}</li>
+                {% endfor %}
+                {% if addresses.instructions %}
+                    <li>Instructions:<ul>
+                        {% for instruction in addresses.instructions %}<li>{{ instruction }}</li>{% endfor %}
+                    </ul></li>
+                {% endif %}
+            </ul></li>
+            {% endif %}
         </ul>
         <h2>Section-by-Section Analysis</h2>
         {% for markup in sxs_markup %}


### PR DESCRIPTION
There are several new fields per notice. This alters the markup so that they get displayed (if in a non-pretty way.)
