### PR TITLE
Travis Tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ install:
    - echo "yes" | sudo add-apt-repository ppa:chris-lea/node.js
    - sudo apt-get update
    - sudo apt-get install nodejs phantomjs
-   - sudo npm install -g grunt-cli grunt-init
+   - cd front_end
+   - npm install grunt-cli grunt-init
    - npm install
+   - cd ..
 script:
     - export PYTHONPATH=.
     - cd static_html_generation


### PR DESCRIPTION
Travis no longer fails, but unfortunately not because the jasmine test works. Instead, I fixed a broken command (an extra cd).

The Jasmine error looks like a problem with the grunt integration. See https://github.com/gruntjs/grunt-contrib-jasmine/issues/64.
