### PR TITLE
#61. Removes duplicated ids in the appendix table of contents

### DIFF
--- a/static_html_generation/templates/simpler.html
+++ b/static_html_generation/templates/simpler.html
@@ -42,7 +42,7 @@
           </nav> 
         </div>
          {%if tree.TOC %}
-            {% with nav_class='regulation-nav' toc_items=tree.TOC toc_id='menu' %}
+            {% with nav_class='regulation-nav' toc_items=tree.TOC top_toc=True %}
                {% include "toc.html" %} 
             {% endwith %}
          {%endif%}  

--- a/static_html_generation/templates/toc.html
+++ b/static_html_generation/templates/toc.html
@@ -1,5 +1,5 @@
-<nav {% if toc_id %}id="{{ toc_id }}" {% endif %}class="panel" role="navigation">
-    <ol class="{{nav_class}}"{% if toc_id %} id="table-of-contents"{% endif %}>
+<nav {% if top_toc %}id="menu" {% endif %}class="panel" role="navigation">
+    <ol class="{{nav_class}}"{% if top_toc %} id="table-of-contents"{% endif %}>
         {% for item in toc_items %}
             <li><a href="{{item.url}}">{{item.label}}</a></li>
         {% endfor %}


### PR DESCRIPTION
Straightforward template change to distinguish the top TOC from appendix TOCs.
