### PR TITLE
Split TOC data up a bit more

### DIFF
--- a/regserver/regulations/generator/generator.py
+++ b/regserver/regulations/generator/generator.py
@@ -1,3 +1,4 @@
+import re
 
 from django.conf import settings 
 
@@ -112,9 +113,20 @@ def get_regulation_section(regulation, version, full_reference):
     return full_regulation
 
 def get_regulation(regulation, version):
-    """ Get the regulation JSON tree. """
+    """ Get the regulation JSON tree. Manipulate the label a bit for easier
+    access in the templates."""
     api = api_reader.Client(settings.API_BASE)
-    return api.regulation(regulation, version)
+    reg =  api.regulation(regulation, version)
+    title = reg['label']['title']
+    # up till the paren
+    match = re.search('part \d+[^\w]*([^\(]*)', title, re.I)  
+    if match:
+        reg['label']['title_clean'] = match.group(1).strip()
+    match = re.search('\(regulation (\w+)\)', title, re.I)
+    if match:
+        reg['label']['reg_letter'] = match.group(1)
+
+    return reg
 
 def get_builder(regulation, version, inline_applier, p_applier, s_applier):
     """ Returns an HTML builder with the appliers, and the regulation tree. """

--- a/regserver/regulations/generator/layers/toc_applier.py
+++ b/regserver/regulations/generator/layers/toc_applier.py
@@ -1,3 +1,6 @@
+#vim: set fileencoding=utf-8
+import re
+
 from regulations.generator.node_types import to_markup_id
 
 class TableOfContentsLayer(object):
@@ -9,8 +12,42 @@ class TableOfContentsLayer(object):
             layer_elements = self.layer[text_index]
 
             toc_list = []
-            for element in layer_elements:
-                element_url = to_markup_id(element['index']);
-                toc_list.append({'url': "#%s" % "-".join(element_url),
-                'label': element['title']})
+            for data in layer_elements:
+                element_url = to_markup_id(data['index']);
+                element = {
+                    'url': "#%s" % "-".join(element_url),
+                    'label': data['title']
+                }
+                self.section(element, data)
+                self.appendix_supplement(element, data)
+                toc_list.append(element)
             return ('TOC', toc_list)
+
+    def section(self, element, data):
+        """Try to manipulate a section TOC item"""
+        if len(data['index']) == 2 and data['index'][1].isdigit():
+            element['is_section'] = True
+            element['section'] = '.'.join(data['index'])
+            element['sub_label'] = re.search(element['section'] 
+                    + r'[^\w]*(.*)', data['title']).group(1)
+    
+    def appendix_supplement(self, element, data):
+        """Handle items pointing to an appendix or supplement"""
+        if len(data['index']) == 2 and data['index'][1].isalpha():
+            if data['index'][1] == 'Interpretations':
+                element['is_supplement'] = True
+            else:
+                element['is_appendix'] = True
+            
+            segments = self.try_split(data['title'], (u'—', '-'))
+            if segments:
+                element['label'], element['sub_label'] = segments
+
+
+    def try_split(self, text, chars):
+        """Utility method for splitting a string by one of multiple chars"""
+        for c in chars:
+            segments = text.split(c)
+            if len(segments) > 1:
+                return [s.strip() for s in segments]
+

--- a/regserver/regulations/generator/templates/toc.html
+++ b/regserver/regulations/generator/templates/toc.html
@@ -1,10 +1,24 @@
 {% comment %}
     For the slide-out table of contents
 {% endcomment %}
+{% if tree.meta %}
+<!-- 
+    Title {{ tree.meta.cfr_title_number }}: {{ tree.meta.cfr_title_text }}
+    Part {{ tree.label.title_clean|title }} {% if tree.label.reg_letter %}(Regulation {{ tree.label.reg_letter }}){% endif %}
+-->
+{% endif %}
 <nav {% if top_toc %}id="menu" class="panel"{% endif %} role="navigation">
     <ol class="{{nav_class}}"{% if top_toc %} id="table-of-contents"{% endif %}>
         {% for item in toc_items %}
-            <li><a href="{{item.url}}">{{item.label|safe}}</a></li>
+            {% if item.is_section %}
+                <li><a href="{{item.url}}">§&nbsp;{{item.section}} {{item.sub_label|safe}}</a></li>
+            {% elif item.is_appendix %}
+                <li><a href="{{item.url}}">{{item.label|safe}} {{item.sub_label|safe}}</a></li>
+            {% elif item.is_supplement %}
+                <li><a href="{{item.url}}">{{item.label|safe}} {{item.sub_label|safe}}</a></li>
+            {% else %}
+                <li><a href="{{item.url}}">{{item.label|safe}}</a></li>
+            {% endif %}
         {% endfor %}
     </ol>
     {% if top_toc %}

--- a/regserver/regulations/tests/generator_tests.py
+++ b/regserver/regulations/tests/generator_tests.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from mock import patch
+
 from regulations.generator import generator
 
 
@@ -21,3 +23,29 @@ class GeneratorTest(TestCase):
         single = generator.get_single_section(full_regulation, '14-1')
         self.assertEquals(None, single)
 
+    @patch('regulations.generator.generator.api_reader')
+    def test_get_regulation_extra_fields(self, api_reader):
+        reg = {'text': '', 'children': [], 'label': {
+            'text': '8675', 
+            'parts': ['8675'],
+            'title': 'Contains no part info'
+        }}
+        api_reader.Client.return_value.regulation.return_value = reg
+
+        r = generator.get_regulation('8675', 'ver')
+        self.assertFalse('title_clean' in r['label'])
+        self.assertFalse('reg_letter' in r['label'])
+
+        reg['label']['title'] = 'part 8675 - Some title'
+        r = generator.get_regulation('8675', 'ver')
+        self.assertTrue('title_clean' in r['label'])
+        self.assertEqual('Some title', r['label']['title_clean'])
+        self.assertFalse('reg_letter' in r['label'])
+
+        del reg['label']['title_clean']
+        reg['label']['title'] = 'part 8675 - Some title (RegUlation RR)'
+        r = generator.get_regulation('8675', 'ver')
+        self.assertTrue('title_clean' in r['label'])
+        self.assertEqual('Some title', r['label']['title_clean'])
+        self.assertTrue('reg_letter' in r['label'])
+        self.assertEqual('RR', r['label']['reg_letter'])

--- a/regserver/regulations/tests/layers_toc_applier_tests.py
+++ b/regserver/regulations/tests/layers_toc_applier_tests.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+
+from regulations.generator.layers.toc_applier import *
+
+class TableOfContentsLayerTest(TestCase):
+    
+    def test_section(self):
+        toc = TableOfContentsLayer(None)
+        el = {}
+        toc.section(el, {'index': ['1']})
+        self.assertEqual({}, el)
+
+        toc.section(el, {'index': ['1', '2', '3']})
+        self.assertEqual({}, el)
+
+        toc.section(el, {'index': ['1', 'B']})
+        self.assertEqual({}, el)
+
+        toc.section(el, {'index': ['1', 'Interpretations']})
+        self.assertEqual({}, el)
+
+        toc.section(el, {'index': ['1', '2'], 'title': '1.2 - Awesome'})
+        self.assertEqual(el, {
+            'is_section': True,
+            'section': '1.2',
+            'sub_label': 'Awesome'
+        })
+
+        toc.section(el, {'index': ['2', '1'], 'title': '2.1Sauce'})
+        self.assertEqual(el, {
+            'is_section': True,
+            'section': '2.1',
+            'sub_label': 'Sauce'
+        })
+
+    def test_appendix_supplement(self):
+        toc = TableOfContentsLayer(None)
+        el = {}
+        toc.appendix_supplement(el, {'index': ['1']})
+        self.assertEqual({}, el)
+
+        toc.appendix_supplement(el, {'index': ['1', '2', '3']})
+        self.assertEqual({}, el)
+
+        toc.appendix_supplement(el, {'index': ['1', 'B', '3']})
+        self.assertEqual({}, el)
+
+        toc.appendix_supplement(el, {'index': ['1', 'Interpretations', '3']})
+        self.assertEqual({}, el)
+
+        toc.appendix_supplement(el, {'index': ['1', 'B'], 
+            'title': 'Appendix B - Bologna'})
+        self.assertEqual(el, {
+            'is_appendix': True,
+            'label': 'Appendix B',
+            'sub_label': 'Bologna'
+        })
+
+        el = {}
+        toc.appendix_supplement(el, {'index': ['1', 'Interpretations'], 
+            'title': 'Supplement I to 8787 - I am Iron Man'})
+        self.assertEqual(el, {
+            'is_supplement': True,
+            'label': 'Supplement I to 8787',
+            'sub_label': 'I am Iron Man'
+        })
+
+    def test_try_split(self):
+        toc = TableOfContentsLayer(None)
+        self.assertEqual(['a', 'xb'], toc.try_split('a:xb', ('|', ':', 'x')))


### PR DESCRIPTION
Provide access to:
- Regulation "Title"
- Regulation Letter
- TOC Section number
- TOC Section title
- TOC if element is a Section/Appendix/Supplement
- TOC access to label and sub-label for Appendix, Supplement

Modify the template to show how these vars can be used

Tests
