### PR TITLE
Making definitions work again

### DIFF
--- a/regserver/regulations/generator/layers/utils.py
+++ b/regserver/regulations/generator/layers/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from django.template import Context
 import re
 
 def convert_to_python(data):
@@ -19,3 +20,7 @@ def convert_to_python(data):
         return list(map(convert_to_python, data))
     
     return data
+
+def render_template(template, context):
+    c = Context(context)
+    return template.render(c).strip('\n')

--- a/regserver/regulations/generator/templates/definition_citation.html
+++ b/regserver/regulations/generator/templates/definition_citation.html
@@ -1,4 +1,4 @@
 {% comment %}
     Links to definitions in the regulation text
 {% endcomment %}
-<a href="{{citation.url}}" class="citation definition" data-definition="{{citation.url}}">{{citation.label}}</a>
+<a href="{{citation.url}}" class="citation definition" data-definition="{{citation.definition_reference}}">{{citation.label}}</a>

--- a/regserver/regulations/tests/layers_definitions_tests.py
+++ b/regserver/regulations/tests/layers_definitions_tests.py
@@ -3,20 +3,25 @@ from mock import patch
 from unittest import TestCase
 
 class DefinitionsLayerTest(TestCase):
-    @patch('regulations.generator.layers.internal_citation.loader')
-    def test_create_definition_link(self, loader):
-        rt = DefinitionsLayer.create_definition_link('abc', ['202', '3'])
-        context = loader.get_template.return_value.render.call_args[0][0]
-        self.assertEquals('#202-3', context['citation']['url'])
+    def test_create_url(self):
+        url = DefinitionsLayer.create_url(['303', '1'])
+        self.assertEquals('#303-1', url)
 
-    @patch('regulations.generator.layers.internal_citation.loader')
-    def test_create_layer_pair(self, loader):
+    def test_create_url_single(self):
+        url = DefinitionsLayer.create_url(['303'])
+        self.assertEquals('#303', url)
+
+    def test_create_definition_reference(self):
+        ref = DefinitionsLayer.create_definition_reference(['303', '1'])
+        self.assertEquals('303-1', ref)
+
+    def test_create_definition_link(self):
         layer = {
             '202-3':{'ref':'account:202-2-a'},
             'referenced':{'account:202-2-a': {'reference':'202-2-a'}}
-        }
-
+            }
         dl = DefinitionsLayer(layer)
-        layer_pair = dl.create_layer_pair('I have an account', (10, 16), layer['202-3'])
-        context = loader.get_template.return_value.render.call_args[0][0]
-        self.assertEquals('#202-2-a', context['citation']['url'])
+        definition_link = dl.create_definition_link('account', ['202', '3'])
+
+        url = '<a href="#202-3" class="citation definition" data-definition="202-3">account</a>'
+        self.assertEquals(definition_link, url)


### PR DESCRIPTION
The templates previously provided the anchor character '#'. This is now removed since we generate it instead. Also, we didn't have any testing around the definitions layer, so added that. 

I'd missed the real fix in an earlier iteration of this. Now, this fixes the data-definition attribute. We've got a better design now, and the href and data-definition attributes are independent entities. 
