### PR TITLE
Footer try 2

### DIFF
--- a/regserver/regserver/settings/base.py
+++ b/regserver/regserver/settings/base.py
@@ -121,6 +121,7 @@ TEMPLATE_DIRS = (
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
     root("templates"),
+    root('regulations/static/regulations/ip/templates'),
     root('regulations/generator/templates'),
 )
 

--- a/regserver/regulations/generator/templates/chrome.html
+++ b/regserver/regulations/generator/templates/chrome.html
@@ -83,9 +83,7 @@
 </div> <!-- /.secondary-content -->
 </div> <!-- /.wrap -->
 
-<footer>
-    <small>Brought to you by the <abbr title="Consumer Financial Protection Buereau">CFPB</abbr> Technology &amp; Innovation Team</small>
-</footer>
+{% include "footer.html" %}
 
 {% endblock %}
 

--- a/regserver/regulations/generator/templates/footer.html
+++ b/regserver/regulations/generator/templates/footer.html
@@ -1,0 +1,4 @@
+{% comment %}
+    Placeholder template for the footer. To add content to the footer, create a 
+templates dir in your django root, then create a footer.html file inside that.
+{% endcomment %}


### PR DESCRIPTION
This adds a blank footer template, which can be overridden. This also updates the search locations to include the "ip" directory (if present). This strategy mixes concerns a bit, as the ip directory has previously solely been used for static assets. It's something we should revisit later, but I don't think it's a major harm.
