### PR TITLE
A first cut at displaying section by section analysis through Django

### DIFF
--- a/regserver/regserver/urls.py
+++ b/regserver/regserver/urls.py
@@ -5,8 +5,9 @@ from regulations.views.chrome import ChromeParagraphView, ChromeSectionView
 from regulations.views.partial import PartialInterpView, PartialRegulationView
 from regulations.views.partial import PartialParagraphView, PartialSectionView
 from regulations.views.diff import PartialSectionDiffView
+from regulations.views.partial_sxs import ParagraphSXSView
 
-#Re-usable URL patterns. 
+#Re-usable URL patterns.
 version_pattern = r'(?P<version>[-\d\w]+)'
 newer_version_pattern = r'(?P<newer_version>[-\d\w]+)'
 
@@ -14,13 +15,14 @@ reg_pattern = r'(?P<label_id>[\d]+)'
 section_pattern = r'(?P<label_id>[\d]+[-][\w]+)'
 interp_pattern = r'(?P<label_id>[-\d\w]+[-]Interp)'
 paragraph_pattern = r'(?P<label_id>[-\d\w]+)'
+notice_pattern = r'(?P<notice_id>[\d]+[-][\d]+)'
 
 
 urlpatterns = patterns('',
     #A regulation section with chrome
     #Example: http://.../regulation/201-4/2013-10704
     url(r'^regulation/%s/%s$' % (section_pattern, version_pattern),
-        ChromeSectionView.as_view(), 
+        ChromeSectionView.as_view(),
         name='chrome_section_view'),
     #Interpretation of a section/paragraph or appendix
     #Example: http://.../regulation/201-4-Interp/2013-10704
@@ -29,7 +31,7 @@ urlpatterns = patterns('',
         name='chrome_interp_view'),
     #The whole regulation with chrome
     #Example: http://.../regulation/201/2013-10704
-    url(r'^regulation/%s/%s$' % (reg_pattern, version_pattern), 
+    url(r'^regulation/%s/%s$' % (reg_pattern, version_pattern),
         ChromeRegulationView.as_view(),
         name='chrome_regulation_view'),
     #A regulation paragraph with chrome
@@ -41,7 +43,7 @@ urlpatterns = patterns('',
     #A regulation section without chrome
     #Example: http://.../partial/201-4/2013-10704
     url(r'^partial/%s/%s$' % (section_pattern, version_pattern),
-        PartialSectionView.as_view(), 
+        PartialSectionView.as_view(),
         name='partial_section_view'),
     #An interpretation of a section/paragraph or appendix without chrome.
     #Example: http://.../partial/201-2-Interp/2013-10704
@@ -50,16 +52,22 @@ urlpatterns = patterns('',
         name='partial_interp_view'),
     #The whole regulation without chrome; not too useful; added for symmetry
     #Example: http://.../partial/201/2013-10704
-    url(r'^partial/%s/%s$' % (reg_pattern, version_pattern), 
+    url(r'^partial/%s/%s$' % (reg_pattern, version_pattern),
         PartialRegulationView.as_view(),
         name='partial_regulation_view'),
-    #A regulation paragraph without chrome. 
+    #A regulation paragraph without chrome.
     #Example: http://.../partial/201-2-g/2013-10704
     url(r'^partial/%s/%s$' % (paragraph_pattern, version_pattern),
         PartialParagraphView.as_view(),
         name='partial_paragraph_view'),
     #A diff view of a section (without chrome)
-    url(r'^partial/diff/%s/%s/%s' % (section_pattern, version_pattern, newer_version_pattern), 
-        PartialSectionDiffView.as_view(), 
-        name='partial_section_diff_view'), 
+    url(r'^partial/diff/%s/%s/%s$' % (
+        section_pattern, version_pattern, newer_version_pattern),
+        PartialSectionDiffView.as_view(),
+        name='partial_section_diff_view'),
+    #A section by section paragraph (without chrome)
+    #Example: http://.../partial/sxs/201-2-g/2011-1738
+    url(r'^partial/sxs/%s/%s$' % (paragraph_pattern, notice_pattern),
+        ParagraphSXSView.as_view(),
+        name='paragraph_sxs_view'),
 )

--- a/regserver/regulations/generator/generator.py
+++ b/regserver/regulations/generator/generator.py
@@ -126,6 +126,26 @@ def get_all_notices():
     return notices.fetch_all(api)
 
 
+def get_notice(document_number):
+    """ Get a the data from a particular notice, given the Federal Register
+    document number. """
+
+    api = api_reader.Client(settings.API_BASE)
+    return api.notice(document_number)
+
+
+def get_sxs(label_id, notice_doc_number):
+    """ Given a paragraph label_id, find the sxs analysis for that paragraph if
+    it exists and has content. The analysis comes from the Federal REgister
+    notice_doc_number. """
+
+    notice = get_notice(notice_doc_number)
+    all_sxs = notice['section_by_section']
+
+    relevant_sxs = notices.find_label_in_sxs(all_sxs, label_id)
+    return relevant_sxs
+
+
 def get_diff_json(regulation, older, newer):
     api = api_reader.Client(settings.API_BASE)
     return api.diff(regulation, older, newer)

--- a/regserver/regulations/generator/templates/paragraph-sxs.html
+++ b/regserver/regulations/generator/templates/paragraph-sxs.html
@@ -1,0 +1,19 @@
+
+{% if sxs.label %}
+    <div id="{{sxs.label}}">
+{% else %}
+    <div>
+{% endif %}
+
+<h{{sxs.depth}}> {{sxs.title}} </h{{sxs.depth}}>
+
+{% for p in sxs.paragraphs %}
+    <p> {{p|safe}} </p>
+{% endfor %}
+
+{% for c in sxs.children %}
+    {% with sxs=c template_name='paragraph-sxs.html' %}
+        {%include template_name  %}
+    {% endwith %}
+{% endfor %}
+</div>

--- a/regserver/regulations/views/partial_sxs.py
+++ b/regserver/regulations/views/partial_sxs.py
@@ -1,0 +1,31 @@
+#vim: set encoding=utf-8
+from django.views.generic.base import TemplateView
+from django.http import Http404
+
+from regulations.generator import generator
+from regulations.generator import notices
+
+
+class ParagraphSXSView(TemplateView):
+    """ Given a regulation paragraph and a Federal Register notice number,
+    display the appropriate section by section analyses."""
+    template_name = 'paragraph-sxs.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(ParagraphSXSView, self).get_context_data(**kwargs)
+
+        label_id = context['label_id']
+        notice_id = context['notice_id']
+
+        paragraph_sxs = generator.get_sxs(label_id, notice_id)
+
+        if paragraph_sxs is None:
+            raise Http404
+
+        notices.add_depths(paragraph_sxs, 3)
+
+        paragraph_sxs['children'] =\
+            notices.filter_labeled_children(paragraph_sxs)
+        context['sxs'] = paragraph_sxs
+
+        return context


### PR DESCRIPTION
This makes some assumptions about SXS analysis (namely around how we want to display things). We'll have to clarify these later. Also, the HTML for the notice is obviously not how we want it, but it's a placeholder until the front end folks can take a look at this. 

The URL for accessing a SXS paragraph is as follows: 

http://127.0.0.1:8001/partial/sxs/204-30/2012-1728

The first set of numbers is the regulation section, the second set is the Federal Register notice. 
