### PR TITLE
Don't hard-code the search url

### DIFF
--- a/regserver/regulations/generator/templates/drawer.html
+++ b/regserver/regulations/generator/templates/drawer.html
@@ -42,7 +42,7 @@
         </ul>
     </div> <!--/#history-->
     <div id="search" class="toc-container hidden">
-        <form action="/partial/search" method="GET">
+        <form action="{% url 'search' %}" method="GET">
             <h3>Search</h3>
             <input type="text" name="q" /><input type="submit" />
             <hr />


### PR DESCRIPTION
Quick fix for search results if the base url isn't "/".
