### PR TITLE
Fix a few issues retrieving analyses of commentary

### DIFF
--- a/regserver/regulations/generator/layers/analyses.py
+++ b/regserver/regulations/generator/layers/analyses.py
@@ -23,18 +23,23 @@ class SectionBySectionLayer(object):
         """Return a pair of field-name + analyses if they apply; include all
         children"""
         analyses = []
+        requested = text_index.split('-')
+        requested_prefix = list(takewhile(lambda k: k != 'Interp', requested))
+
         for key in self.layer:
-            requested = text_index.split('-')
             key_parts = key.split('-')
 
-            # Interpretations have an added complication
+            # Interpretations have an added complication:
+            # 1005-2-Interp-2 is a child of 1005-Interp
             key_prefix = takewhile(lambda k: k != 'Interp', key_parts)
-            key_prefix = list(key_prefix)[:len(requested)]
-            if requested[-1] == 'Interp' and requested[:-1] == key_prefix:
+            key_prefix = list(key_prefix)[:len(requested_prefix)]
+            if (requested[-1] == 'Interp' and key_prefix == requested_prefix
+                    and 'Interp' in key_parts):
                 analyses.extend(self.to_template_dict(key))
 
             # Simple Case: lexical child
-            elif key_parts[:len(requested)] == requested:
+            elif (key_parts[:len(requested)] == requested
+                  and ('Interp' in requested) == ('Interp' in key_parts)):
                 analyses.extend(self.to_template_dict(key))
 
         if analyses:

--- a/regserver/regulations/tests/layers_analyses_tests.py
+++ b/regserver/regulations/tests/layers_analyses_tests.py
@@ -34,6 +34,35 @@ class SectionBySectionLayerTest(TestCase):
 
         self.assertEqual(None, sxs.apply_layer("222-22"))
 
+    def test_apply_layer_interps(self):
+        layer = {
+            '111-22': [{'reference': ['2007-22', '111-22']}],
+            '111-22-Interp': [{'reference': ['2007-22', '111-22-Interp']}],
+            '111-22-Interp-2': [{'reference': ['2007-22', '111-22-Interp-2']}]
+        }
+        sxs = SectionBySectionLayer(layer)
+
+        _, value = sxs.apply_layer('111-22')
+        self.assertEqual(
+            [{'doc_number': '2007-22', 'label_id': '111-22', 'text': '22'}],
+            value)
+        _, value = sxs.apply_layer('111-22-Interp')
+        self.assertEqual([
+            {'doc_number': '2007-22', 'label_id': '111-22-Interp',
+             'text': 'Comment for 111.22'},
+            {'doc_number': '2007-22', 'label_id': '111-22-Interp-2',
+             'text': 'Comment for 111.22-2'}], value)
+        _, value = sxs.apply_layer('111-22-Interp')
+        self.assertEqual([
+            {'doc_number': '2007-22', 'label_id': '111-22-Interp',
+             'text': 'Comment for 111.22'},
+            {'doc_number': '2007-22', 'label_id': '111-22-Interp-2',
+             'text': 'Comment for 111.22-2'}], value)
+        _, value = sxs.apply_layer('111-22-Interp-2')
+        self.assertEqual([
+            {'doc_number': '2007-22', 'label_id': '111-22-Interp-2',
+             'text': 'Comment for 111.22-2'}], value)
+
     def test_to_template_dict(self):
         layer = {'555-22-Interp': [{'reference': ['aaa', '555-22-Interp']},
                                    {'reference': ['bbb', '555-22-Interp']},


### PR DESCRIPTION
Analyses of commentary wasn't appearing in the interpretations section.

This fixes that and adds tests to prevent it from happening in the future.
