### PR TITLE
List all paragraph markers in the rhs

### DIFF
--- a/regserver/regulations/generator/templates/sidebar.html
+++ b/regserver/regulations/generator/templates/sidebar.html
@@ -12,5 +12,17 @@
             {% endif %}
             </div>
         </section> <!-- /.regs-meta -->
+        <section id="permalinks" class="regs-meta">
+            <h4 class="expandable">Bookmark-able Links</h4>
+            <div class="chunk expand-drawer">
+            {% if permalinks %}
+                <ul>
+                    {% for permalink in permalinks %}
+                        <li><a href="{% url 'chrome_section_view' permalink.section_id version %}#{{ permalink.label_id }}">{{ permalink.text }}</a></li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+            </div>
+        </section> <!-- /.regs-meta -->
     </div> <!-- /#sidebar-content -->
 </div> <!-- /.secondary-content -->

--- a/regserver/regulations/tests/views_sidebar_tests.py
+++ b/regserver/regulations/tests/views_sidebar_tests.py
@@ -18,6 +18,16 @@ class ViewsSideBarViewTest(TestCase):
             ],
             '1111-7-a': [{'reference': ['1992-1', '1111-7-a']}]
         }
+        api_reader.ApiReader.return_value.regulation.return_value = {
+            'label': ['876', '12'],
+            'children': [
+                {'label': ['876', '12', 'a'], 'children': []},
+                {'label': ['876', '12', 'b'], 'children': []},
+                {'label': ['876', '12', 'c'], 'children': [
+                    {'label': ['876', '12', 'c', '1'], 'children': []}
+                ]}
+            ]
+        }
         response = Client().get('/partial/sidebar/1111-7/verver')
         self.assertTrue(bool(re.search(r'\b7\b', response.content)))
         self.assertTrue('7(a)' in response.content)
@@ -25,6 +35,15 @@ class ViewsSideBarViewTest(TestCase):
         self.assertTrue('1111-7' in response.content)
         self.assertTrue('1992-1' in response.content)
         self.assertTrue('1111-7-a' in response.content)
+        self.assertTrue('876-12' in response.content)
+        self.assertTrue('876-12-a' in response.content)
+        self.assertTrue('876-12-b' in response.content)
+        self.assertTrue('876-12-c' in response.content)
+        self.assertTrue('876-12-c-1' in response.content)
+        self.assertTrue('12(a)' in response.content)
+        self.assertTrue('12(b)' in response.content)
+        self.assertTrue('12(c)' in response.content)
+        self.assertTrue('12(c)(1)' in response.content)
 
     @patch('regulations.views.sidebar.api_reader')
     def test_get_404(self, api_reader):


### PR DESCRIPTION
This patch just adds the list of markers for the current section/paragraph/etc. to the sidebar
