### PR TITLE
Add link to bottom of interpretation for jumping to the interpretation within the tool

### DIFF
--- a/regserver/regulations/generator/layers/interpretations.py
+++ b/regserver/regulations/generator/layers/interpretations.py
@@ -27,12 +27,14 @@ class InterpretationsLayer(object):
             response.render()
 
             context = {
+                'for_markup_id': text_index,
+                'label_id': reference,
                 'markup': response.content,
-                'for_markup_id': text_index
             }
 
             #  exclude 'Interp'
             ref_parts = reference.split('-')[:-1]
+            context['section_id'] = '%s-Interp' % ref_parts[0]
 
             if len(ref_parts) == 2:
                 #  Part-Section/Appendix

--- a/regserver/regulations/generator/templates/slide-down-interp.html
+++ b/regserver/regulations/generator/templates/slide-down-interp.html
@@ -9,5 +9,7 @@
     </header>
     <section class="inline-interpretation-content hidden">
         {{ interp.markup | safe }}
+
+        <p><a href="{% url 'chrome_section_view' interp.section_id version %}#{{ interp.label_id }}">Official Interpretation for {{ interp.label }}</a></p>
     </section>
 </section>

--- a/regserver/regulations/tests/layers_interpretations_tests.py
+++ b/regserver/regulations/tests/layers_interpretations_tests.py
@@ -24,9 +24,11 @@ class InterpretationsLayerTest(TestCase):
         il = InterpretationsLayer(layer)
 
         self.assertEqual(il.apply_layer('200-2-b-3-i'), ('interp', {
-            'markup': 'content',
             'for_markup_id': '200-2-b-3-i',
-            'label': '2(b)(3)(i)'
+            'label_id': '200-2-b-3-i-Interp',
+            'label': '2(b)(3)(i)',
+            'markup': 'content',
+            'section_id': '200-Interp',
         }))
 
     @patch('regulations.generator.layers.interpretations.views'


### PR DESCRIPTION
Link now appears at the bottom of each slide-down interp and is ready for styling.
