### PR TITLE
Landing page chrome tweaks

### DIFF
--- a/regserver/regulations/generator/templates/chrome.html
+++ b/regserver/regulations/generator/templates/chrome.html
@@ -38,13 +38,17 @@
 
 <div class="wrap group">
 
+{% block chrome-content %}
 <div id="content-body" class="main-content">
 
     {{ partial_content|safe }}
 
 </div> <!-- /.main-content -->
+{% endblock %}
 
+{% block chrome-sidebar %}
 {{ sidebar_content|safe }}
+{% endblock %}
 
 </div> <!-- /.wrap -->
 

--- a/regserver/regulations/generator/templates/generic_landing.html
+++ b/regserver/regulations/generator/templates/generic_landing.html
@@ -1,48 +1,38 @@
-<div id="main_content">
-{% block reg_main_content %}
-{% endblock %}
+<div id="content-body" class="main-content">
+    <section id="content-wrapper">
+        <section data-base-version="{{ current_version.version }}">
+            {% block reg_main_content %}
+            {% endblock %}
 
-<form action="{% url 'chrome_search' label_id %}" method="GET">
-    <div class="search-box">
-        <input type="text" name="q" /><button type="submit"><i class="minicon-search"></i><strong class="icon-text">Search</strong></button>
-        <input type="hidden" name="version" value="{{current_version.version}}"/>
+            <form action="{% url 'chrome_search' label_id %}" method="GET">
+                <div class="search-box">
+                    <input type="text" name="q" /><button type="submit"><i class="minicon-search"></i><strong class="icon-text">Search</strong></button>
+                    <input type="hidden" name="version" value="{{current_version.version}}"/>
+                </div>
+            </form>
+
+            <div id="disclaimer">
+                {% block legal_disclaimer %}
+                {% endblock %}
+            </div>
+        </section>
+    </section>
+</div>
+
+
+<div id="sidebar" class="secondary-content">
+    <div id="sidebar-content" class="sidebar-inner">
+        {% if new_version %}
+            <h3> New version to be effective: {{new_version.by_date|date:"m/d/Y"}} </h3>
+            <ul>
+                <li> <a href="{% url 'chrome_section_view' reg_first_section new_version.version %}">View new version</a></li>
+                {%comment %} 
+                <li> <a href="{% url 'chome_section_diff_view' reg_first_section current_version.version new_version.version %}">Compare new version</a></li>
+                {% endcomment %}
+            </ul>
+        {% endif %}
+
+        {% block reg_sidebar %}
+        {% endblock %}
     </div>
-</form>
-
-<div id="footer">
-    {% block legal_disclaimer %}
-    {% endblock %}
-
-    <h3> About the Tool </h3>
-
-    <p>
-    Brought to you by the CFPB Technology and Innovation Team. This site is an
-    open source project and developed by open source software.  <br />
-    <a href="http://cfpb.github.io/eregs/">http://cfpb.github.io/eregs/</a>
-    </p>
-
-    <h4> Feedback about the tool: </h4>
-    <a href="mailto:CFPB_eRegs_Team@cfpb.gov">CFPB_eRegs_Team@cfpb.gov</a>
-</div>
-
-</div>
-
-
-<div id="sidebar">
-{% if new_version %}
-    <h3> New version to be effective: {{new_version.by_date|date:"d/m/Y"}} </h3>
-    <ul>
-        <li> <a href="{% url 'chrome_section_view' reg_first_section new_version.version %}">View new version</a></li>
-        {%comment %} 
-        <li> <a href="{% url 'chome_section_diff_view' reg_first_section current_version.version new_version.version %}">Compare new version</a></li>
-        {% endcomment %}
-    </ul>
-{% endif %}
-
-{% block reg_sidebar %}
-{% endblock %}
-
-<h4> Questions about interpretation or application </h4>
-<p> <a href="mailto:CFPB_reginquiries@cfpb.gov">CFPB_reginquiries@cfpb.gov</a> </p>
-<p> (202) 435-7700 </p>
 </div>

--- a/regserver/regulations/generator/templates/landing-chrome.html
+++ b/regserver/regulations/generator/templates/landing-chrome.html
@@ -1,0 +1,10 @@
+{% extends "chrome.html" %}
+
+{% comment %}
+Does not wrap the content in a #content-body; this is instead provided by the
+landing page content (which also provides the sidebar).
+{% endcomment %}
+
+{% block chrome-content %}
+{{ partial_content|safe }}
+{% endblock %}

--- a/regserver/regulations/views/chrome.py
+++ b/regserver/regulations/views/chrome.py
@@ -17,6 +17,7 @@ from regulations.views.sidebar import SideBarView
 class ChromeView(TemplateView):
     """ Base class for views which wish to include chrome. """
     template_name = 'chrome.html'
+    has_sidebar = True
 
     def get(self, request, *args, **kwargs):
         """Override GET so that we can catch and propagate any errors in the
@@ -63,12 +64,13 @@ class ChromeView(TemplateView):
 
         context['partial_content'] = self.process_partial(context)
 
-        sidebar_view = SideBarView.as_view()
-        response = sidebar_view(self.request, label_id=label_id,
-                                version=version)
-        self._assert_good(response)
-        response.render()
-        context['sidebar_content'] = response.content
+        if self.has_sidebar:
+            sidebar_view = SideBarView.as_view()
+            response = sidebar_view(self.request, label_id=label_id,
+                                    version=version)
+            self._assert_good(response)
+            response.render()
+            context['sidebar_content'] = response.content
 
         appliers = utils.handle_specified_layers(
             'toc,meta', part, version, self.partial_class.sectional_links)
@@ -151,7 +153,9 @@ class ChromeSectionDiffView(ChromeView):
 
 class ChromeLandingView(ChromeView):
     """Landing page with chrome"""
+    template_name = 'landing-chrome.html'
     partial_class = PartialSectionView  # Needed to know sectional status
+    has_sidebar = False
 
     def process_partial(self, context):
         """Landing page isn't a TemplateView"""


### PR DESCRIPTION
- Remove CFPB references
- Use blocks to allow the sidebar and content to come from the same template
- Use a flag to prevent sidebar from being generated
