### PR TITLE
Diffs: Added nodes are selected more carefully

### DIFF
--- a/regserver/regulations/generator/layers/diff_applier.py
+++ b/regserver/regulations/generator/layers/diff_applier.py
@@ -61,15 +61,20 @@ class DiffApplier(object):
                 else:
                     original.update(node)
 
+    def is_child_of_requested(self, label):
+        """ Return true if the label is a child of the requested label.  """
+        if label.startswith(self.label_requested + '-'):
+            return True
+
+    def relevant_added(self, label):
+        """ Get the operations that add nodes, for the requested
+        section/pargraph. """
+
+        if self.diff[label]['op'] == self.ADDED_OP and self.is_child_of_requested(label):
+            return True
+
     def tree_changes(self, original_tree):
         """ Apply additions to the regulation tree. """
-
-        def relevant_added(label):
-            """ Get the operations that add nodes, for the requested
-            section/pargraph. """
-
-            if self.diff[label]['op'] == self.ADDED_OP and label.startswith(self.label_requested):
-                return True
 
         def node(diff_node, label):
             """ Take diff's specification of a node, and actually turn it into
@@ -81,7 +86,7 @@ class DiffApplier(object):
                 del node['title']
             return node
 
-        new_nodes = [(label, node(self.diff[label]['node'], label)) for label in self.diff if relevant_added(label)]
+        new_nodes = [(label, node(self.diff[label]['node'], label)) for label in self.diff if self.relevant_added(label)]
         reg_text_nodes = [l for l in new_nodes if 'Interp' not in l[0]]
 
         adds = tree_builder.AddQueue()

--- a/regserver/regulations/tests/diff_applier_tests.py
+++ b/regserver/regulations/tests/diff_applier_tests.py
@@ -147,3 +147,9 @@ class DiffApplierTest(TestCase):
 
         da.add_nodes_to_tree(tree, adds)
 
+    def test_child_picking(self):
+        da = self.create_diff_applier()
+        da.label_requested = '204-3'
+
+        self.assertTrue(da.is_child_of_requested('204-3-a'))
+        self.assertFalse(da.is_child_of_requested('204-32'))


### PR DESCRIPTION
This fixes the issue where if you request a diff of section 3 you get a diff of section 32 because of faulty logic. This logic is  a tiny bit better, but really sets us up to tackle this well with interpretations when we're ready to do that. 
