### PR TITLE
Move logo out of -site

### DIFF
--- a/regserver/regulations/generator/templates/chrome.html
+++ b/regserver/regulations/generator/templates/chrome.html
@@ -12,11 +12,10 @@
 
 <header id="site-header" class="reg-header">
 <div class="main-head">
-    {% load static from staticfiles %}
-        <div class="reg-title">
-            <h1><a href="{% url 'regulation_landing_view' tree.label.0 %}">{{ tree.meta.cfr_title_number }} CFR Part {{ tree.label.0 }} <span class="title">{{ tree.title_clean|title }} </span>{% if tree.reg_letter %}(Regulation {{ tree.reg_letter }}){% endif %}</a></h1>
-        </div> <!-- /reg-title -->
-        <img src="{%static "regulations/ip/logo.png" %}" class="logo" alt="Consumer Financial Protection Bureau" width="151px">
+    <div class="reg-title">
+        <h1><a href="{% url 'regulation_landing_view' tree.label.0 %}">{{ tree.meta.cfr_title_number }} CFR Part {{ tree.label.0 }} <span class="title">{{ tree.title_clean|title }} </span>{% if tree.reg_letter %}(Regulation {{ tree.reg_letter }}){% endif %}</a></h1>
+    </div> <!-- /reg-title -->
+    {% include "logo.html" %} 
 </div>
 
 <div class="sub-head">

--- a/regserver/regulations/generator/templates/logo.html
+++ b/regserver/regulations/generator/templates/logo.html
@@ -1,0 +1,3 @@
+{% comment %}
+Logo image/text. Expected to be overwritten.
+{% endcomment %}


### PR DESCRIPTION
The logo template can be (and is) overwritten in ip.
