### PR TITLE
Update breakaway header -- only needs meta layer

### DIFF
--- a/regserver/regulations/generator/templates/breakaway-chrome.html
+++ b/regserver/regulations/generator/templates/breakaway-chrome.html
@@ -7,13 +7,14 @@
 {% endcomment %}
 <div class="full-breakaway">
     <header id="site-header" class="reg-header">
-    <div class="main-head">
-        {% load static from staticfiles %}
-            <img src="{%static "regulations/ip/logo.png" %}" class="logo" alt="Consumer Financial Protection Bureau" width="151px">
+        <div class="main-head">
             <div class="reg-title">
-                <h1>eRegulations > Regulation {{ reg_letter }}</h1>
-            </div> <!-- /site-title -->
-    </div>
+                <h1><a href="{% url 'regulation_landing_view' regulation %}">{{ meta.cfr_title_number }} CFR Part {{ regulation }} 
+                        <span class="title">{{ meta.statutory_name|title }} </span>{% if meta.reg_letter %}(Regulation {{ meta.reg_letter }}){% endif %}
+                </a></h1>
+            </div> <!-- /reg-title -->
+            {% include "logo.html" %} 
+        </div>
     </header>
 
     <div id="breakaway-view">{{ partial_content|safe }}</div>

--- a/regserver/regulations/views/chrome_breakaway.py
+++ b/regserver/regulations/views/chrome_breakaway.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
 
+from regulations.generator import api_reader
 from regulations.views import utils
 from regulations.views.chrome import ChromeView
 from regulations.views.partial_search import PartialSearch
@@ -18,7 +19,10 @@ class ChromeBreakawayView(ChromeView):
         #   Skip ChromeView's implementation
         context = super(ChromeView, self).get_context_data(**kwargs)
 
-        #   @todo: get the regulation letter as well
+        context['regulation'] = context['label_id'].split('-')[0]
+        meta = api_reader.ApiReader().layer('meta',
+            context['regulation'], self.request.GET.get('from_version'))
+        context['meta'] = meta[context['regulation']][0]
 
         content = self.content(context)
         if isinstance(content, HttpResponse):  # error occurred


### PR DESCRIPTION
Makes the non-JS experience match the JS version.
