### PR TITLE
Use section urls rather than interpretation-specific urls

### DIFF
--- a/regserver/regulations/generator/layers/internal_citation.py
+++ b/regserver/regulations/generator/layers/internal_citation.py
@@ -25,18 +25,14 @@ class InternalCitationLayer():
 
     @staticmethod
     def sectional_url_for(label, version):
-        section_url = '-'.join(to_markup_id(label[:2]))
+        if 'Interp' in label:
+            section_url = label[0] + '-Interp'
+        else:
+            section_url = '-'.join(to_markup_id(label[:2]))
         try:
-            if 'Interp' in label and len(label) > 2:
-                url = reverse(
-                    'chrome_interp_view',
-                    kwargs={
-                        'label_id': section_url + '-Interp',
-                        'version': version})
-            else:
-                url = reverse(
-                    'chrome_section_view',
-                    kwargs={'label_id': section_url, 'version': version})
+            url = reverse(
+                'chrome_section_view',
+                kwargs={'label_id': section_url, 'version': version})
         except NoReverseMatch:
             #XXX We have some errors in our layers. Once those are fixed, we
             #need to revisit this.

--- a/regserver/regulations/tests/layers_internal_citation_tests.py
+++ b/regserver/regulations/tests/layers_internal_citation_tests.py
@@ -8,7 +8,7 @@ class InternalCitationLayerTest(TestCase):
         self.assertTrue('999-88/verver#999-88-e' in 
             InternalCitationLayer.sectional_url_for(['999', '88', 'e'],
             'verver'))
-        self.assertTrue('999-88-Interp/verver#999-88-e-Interp-1' in 
+        self.assertTrue('999-Interp/verver#999-88-e-Interp-1' in 
             InternalCitationLayer.sectional_url_for(['999', '88', 'e',
             'Interp', '1'], 'verver'))
         self.assertTrue('999-Interp/verver#999-Interp' in 


### PR DESCRIPTION
We were pointing to the interpretation-specific urls (which were meant to allow the interpretation to be broken up). As we instead need everything in "section" urls, update the internal citation layer piece.
