### PR TITLE
Definitions layer now "sectionally" aware

### DIFF
--- a/regserver/regulations/generator/layers/definitions.py
+++ b/regserver/regulations/generator/layers/definitions.py
@@ -1,4 +1,6 @@
 from django.template import loader, Context
+from django.core.urlresolvers import reverse, NoReverseMatch
+
 from ..node_types import to_markup_id
 import utils
 
@@ -11,11 +13,22 @@ class DefinitionsLayer(object):
         self.defining_template = loader.get_template('layers/defining.html')
         self.citations_template =\
             loader.get_template('layers/definition_citation.html')
+        self.sectional = False
+        self.version = None
 
-    @staticmethod
-    def create_url(citation):
+    def create_url(self, citation):
         """ Create the URL for a definition. """
-        return '#' + '-'.join(to_markup_id(citation))
+
+        url = ''
+        if self.sectional:
+            try:
+                url = reverse('chrome_section_view',
+                              kwargs={'label_id': '-'.join(citation[:2]),
+                                      'version': self.version})
+            except NoReverseMatch:
+                # Error in the data
+                pass
+        return url + '#' + '-'.join(to_markup_id(citation))
 
     @staticmethod
     def create_definition_reference(citation):
@@ -27,7 +40,7 @@ class DefinitionsLayer(object):
 
         context = {
             'citation': {
-                'url': DefinitionsLayer.create_url(citation),
+                'url': self.create_url(citation),
                 'label': original_text,
                 'definition_reference':
                 DefinitionsLayer.create_definition_reference(citation)}}

--- a/regserver/regulations/tests/layers_definitions_tests.py
+++ b/regserver/regulations/tests/layers_definitions_tests.py
@@ -1,14 +1,24 @@
-from regulations.generator.layers.definitions import DefinitionsLayer
 from unittest import TestCase
+
+from regulations.generator.layers.definitions import DefinitionsLayer
+
 
 class DefinitionsLayerTest(TestCase):
     def test_create_url(self):
-        url = DefinitionsLayer.create_url(['303', '1'])
+        dl = DefinitionsLayer(None)
+        url = dl.create_url(['303', '1'])
         self.assertEquals('#303-1', url)
 
-    def test_create_url_single(self):
-        url = DefinitionsLayer.create_url(['303'])
+        url = dl.create_url(['303', '1', 'b'])
+        self.assertEquals('#303-1-b', url)
+
+        url = dl.create_url(['303'])
         self.assertEquals('#303', url)
+
+        dl.sectional = True
+        dl.version = 'vvv'
+        url = dl.create_url(['303', '1', 'b'])
+        self.assertEquals('/303-1/vvv#303-1-b', url)
 
     def test_create_definition_reference(self):
         ref = DefinitionsLayer.create_definition_reference(['303', '1'])
@@ -16,11 +26,12 @@ class DefinitionsLayerTest(TestCase):
 
     def test_create_definition_link(self):
         layer = {
-            '202-3':{'ref':'account:202-2-a'},
-            'referenced':{'account:202-2-a': {'reference':'202-2-a'}}
+            '202-3': {'ref': 'account:202-2-a'},
+            'referenced': {'account:202-2-a': {'reference': '202-2-a'}}
             }
         dl = DefinitionsLayer(layer)
         definition_link = dl.create_definition_link('account', ['202', '3'])
 
-        url = '<a href="#202-3" class="citation definition" data-definition="202-3">account</a>'
+        url = '<a href="#202-3" class="citation definition" '
+        url += 'data-definition="202-3">account</a>'
         self.assertEquals(definition_link, url)


### PR DESCRIPTION
Ultimately, this should make definitions work for both non-JS users and IE users.

Takes lead of the internal citations layer. Also some PEP 8 fixes.
