### PR TITLE
Resolve Cascading Off-By-One Error in Diffs

### DIFF
--- a/regserver/regulations/generator/layers/diff_applier.py
+++ b/regserver/regulations/generator/layers/diff_applier.py
@@ -27,7 +27,10 @@ class DiffApplier(object):
         self.oq = [deque([c]) for c in original]
 
     def insert_text(self, pos, new_text):
-        self.oq[pos-1].extend(['<ins>', new_text, '</ins>'])
+        if pos == len(self.oq):
+            self.oq[pos-1].extend(['<ins>', new_text, '</ins>'])
+        else:
+            self.oq[pos].appendleft('<ins>' + new_text + '</ins>')
 
     def delete_text(self, start, end):
         self.oq[start].appendleft('<del>')
@@ -132,6 +135,8 @@ class DiffApplier(object):
 
                             _, _, new_text = d[1]
 
+                            # Place the new text at the end of the delete for
+                            # readability.
                             self.insert_text(e, new_text)
                 return self.get_text()
         return original

--- a/regserver/regulations/tests/diff_applier_tests.py
+++ b/regserver/regulations/tests/diff_applier_tests.py
@@ -34,9 +34,9 @@ class DiffApplierTest(TestCase):
     def test_insert_text(self):
         da = self.create_diff_applier()
 
-        da.insert_text(2, 'AA')
+        da.insert_text(1, 'AA')
         deque_list = [
-            deque(['a']), deque(['b', '<ins>', 'AA', '</ins>']),
+            deque(['a']), deque(['<ins>AA</ins>', 'b']),
             deque(['c']), deque(['d'])]
         self.assertEquals(da.oq, deque_list)
 


### PR DESCRIPTION
A bug in the diff parser resulted in each insert operation starting the position _after_ it should have. This was fixed when it got to the front-end by more or less subtracting one.

See the test case diff for an example.
