### PR TITLE
Another GA fix

### DIFF
--- a/regserver/regulations/tests/views_utils_test.py
+++ b/regserver/regulations/tests/views_utils_test.py
@@ -81,6 +81,14 @@ class UtilsTest(TestCase):
         self.assertEqual('googid', context['GOOGLE_ANALYTICS_ID'])
         self.assertEqual('googsite', context['GOOGLE_ANALYTICS_SITE'])
 
+        settings.EREGS_GA_ID = ''
+        settings.EREGS_GA_SITE = ''
+
+        context = {}
+        add_extras(context)
+        self.assertEqual('googid', context['GOOGLE_ANALYTICS_ID'])
+        self.assertEqual('googsite', context['GOOGLE_ANALYTICS_SITE'])
+
     @patch('regulations.views.utils.table_of_contents')
     def test_first_section(self, table_of_contents):
         table_of_contents.return_value = [

--- a/regserver/regulations/views/utils.py
+++ b/regserver/regulations/views/utils.py
@@ -65,10 +65,12 @@ def add_extras(context):
     if prefix != '/':   # Strip final slash
         prefix = prefix[:-1]
     context['APP_PREFIX'] = prefix
-    context['GOOGLE_ANALYTICS_SITE'] = getattr(settings, 'EREGS_GA_SITE',
-        getattr(settings, 'GOOGLE_ANALYTICS_SITE', ''))
-    context['GOOGLE_ANALYTICS_ID'] = getattr(settings, 'EREGS_GA_ID',
-        getattr(settings, 'GOOGLE_ANALYTICS_ID', ''))
+    context['GOOGLE_ANALYTICS_SITE'] = getattr(settings, 'EREGS_GA_SITE', '')
+    context['GOOGLE_ANALYTICS_ID'] = getattr(settings, 'EREGS_GA_ID', '')
+
+    for attr in ('GOOGLE_ANALYTICS_SITE', 'GOOGLE_ANALYTICS_ID'):
+        if not context[attr]:
+            context[attr] = getattr(settings, attr, '')
     return context
 
 


### PR DESCRIPTION
This makes it backwards compatible for sites that use the base settings directly (e.g. continuous and demo). This continues to be backwards compatible for sites that do not use the base settings (e.g. production).
