### PR TITLE
Adding the tab title back in

### DIFF
--- a/regserver/regulations/generator/templates/base.html
+++ b/regserver/regulations/generator/templates/base.html
@@ -16,7 +16,7 @@ CSS/Javascript etc., should inherit from this template.
         <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE8" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>
-        PART {{reg_part}} - {{meta.statutory_name}} {%if meta.reg_letter %} (REGULATION {{meta.reg_letter}}) {% endif %}
+        PART {{reg_part}} - {{meta.statutory_name|upper}}{%if meta.reg_letter %} (REGULATION {{meta.reg_letter}}) {% endif %}
         </title>
         <link rel="shortcut icon" type="image/x-icon" href="{%static "regulations/ip/favicon.ico" %}"/>
         <link rel="stylesheet" href="{%static "regulations/css/style.min.css" %}"/>

--- a/regserver/regulations/tests/base_template_test.py
+++ b/regserver/regulations/tests/base_template_test.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+from django.template import RequestContext
+from django.template.loader import get_template
+from django.test import RequestFactory
+
+
+class TemplateTest(TestCase):
+    def test_title_in_base(self):
+        context = {
+            'env': 'dev',
+            'reg_part': '204',
+            'meta': {'reg_letter': 'F', 'statutory_name': 'My Reg'}}
+        request = RequestFactory().get('/fake-path')
+        c = RequestContext(request, context)
+        t = get_template('base.html')
+        rendered = t.render(c)
+
+        title = 'PART 204 - MY REG (REGULATION F)'
+        self.assertTrue(title in rendered)

--- a/regserver/regulations/tests/views_landing_tests.py
+++ b/regserver/regulations/tests/views_landing_tests.py
@@ -13,7 +13,7 @@ class LandingViewTest(TestCase):
         self.assertFalse(reg_versions)
 
     @patch('regulations.views.landing.api_reader')
-    def test_regulation_exists_not(self, api_reader):
+    def test_regulation_exists(self, api_reader):
         api_reader.ApiReader.return_value.regversions.return_value = [{'version':'exists'}]
         reg_versions = landing.regulation_exists('204')
         self.assertTrue(reg_versions)


### PR DESCRIPTION
We add the title for the page back in, using meta instead of the tree.
Also added a test to make sure the title doesn't disappear again. 

The other testing fix is unrelated. We had two test methods with the same name. 
