### PR TITLE
Performance Tweak 1: Limit layers loaded for interpretations

### DIFF
--- a/regserver/regulations/generator/layers/interpretations.py
+++ b/regserver/regulations/generator/layers/interpretations.py
@@ -21,7 +21,7 @@ class InterpretationsLayer(object):
 
             partial_view = views.partial.PartialInterpView.as_view(inline=True)
             request = HttpRequest()
-            request.GET['layers'] = 'terms,graphics,internal,keyterms,paragraph'
+            request.GET['layers'] = 'terms,internal,keyterms,paragraph'
             request.method = 'GET'
             response = partial_view(request, label_id=reference,
                                     version=self.version)


### PR DESCRIPTION
Though hidden, slide-down interpretations effectively add a lot of content to the page, with multiple layers applied. This limits the layers in the slide down to those that are relevant (i.e. no need for TOC, SxS, etc.)

~ 10% boost to loading section 20, which has many interpretations
