### PR TITLE
Performance Tweak 2: Replace re.search + re.escape with a faster string search

### DIFF
--- a/regserver/regulations/generator/layers/layers_applier.py
+++ b/regserver/regulations/generator/layers/layers_applier.py
@@ -1,4 +1,3 @@
-import re
 from lxml import html
 from Queue import PriorityQueue
 from HTMLParser import HTMLParser

--- a/regserver/regulations/generator/layers/location_replace.py
+++ b/regserver/regulations/generator/layers/location_replace.py
@@ -1,5 +1,3 @@
-import re
-
 class LocationReplace(object):
     """ Applies location based layers to XML nodes. We use XML so that we only take into account the original 
     text when we're doing a replacement. """


### PR DESCRIPTION
re.finditer + re.escape is slow. Wrote a quicker version using string.find. This could probably be made more efficient, but as it stands, it's faster than re.

On 1005-Interp (our largest section), this gives a ~16% boost
