### PR TITLE
Performance Tweak 4: Pre-computations in Analysis Layer

### DIFF
--- a/regserver/regulations/generator/layers/analyses.py
+++ b/regserver/regulations/generator/layers/analyses.py
@@ -8,6 +8,16 @@ class SectionBySectionLayer(object):
 
     def __init__(self, layer):
         self.layer = layer
+        # Perform the computations we'll use when applying the layer only once
+        self.precomputations = {}
+        for key in layer:
+            key_parts = key.split('-')
+
+            # Interpretations have an added complication:
+            # 1005-2-Interp-2 is a child of 1005-Interp
+            key_prefix = list(takewhile(lambda k: k != 'Interp', key_parts))
+            self.precomputations[key] = (key_parts, key_prefix,
+                                         'Interp' in key_parts)
 
     def to_template_dict(self, key):
         """Take the reference associated with this SxS and turn it into data
@@ -28,19 +38,15 @@ class SectionBySectionLayer(object):
         requested_prefix = list(takewhile(lambda k: k != 'Interp', requested))
 
         for key in self.layer:
-            key_parts = key.split('-')
-
-            # Interpretations have an added complication:
-            # 1005-2-Interp-2 is a child of 1005-Interp
-            key_prefix = takewhile(lambda k: k != 'Interp', key_parts)
-            key_prefix = list(key_prefix)[:len(requested_prefix)]
+            key_parts, key_prefix, key_is_interp = self.precomputations[key]
+            key_prefix = key_prefix[:len(requested_prefix)]
             if (requested[-1] == 'Interp' and key_prefix == requested_prefix
-                    and 'Interp' in key_parts):
+                    and key_is_interp):
                 analyses.extend(self.to_template_dict(key))
 
             # Simple Case: lexical child
             elif (key_parts[:len(requested)] == requested
-                  and ('Interp' in requested) == ('Interp' in key_parts)):
+                  and ('Interp' in requested) == key_is_interp):
                 analyses.extend(self.to_template_dict(key))
 
         if analyses:


### PR DESCRIPTION
Instead of running these computations for each node, just run it once.

~6% boost on Interp (longest) and 31 (has most analyses)
