### PR TITLE
Performance Tweak 5: Definition, Internal Citation layers cache rendered results

### DIFF
--- a/regserver/regulations/generator/layers/definitions.py
+++ b/regserver/regulations/generator/layers/definitions.py
@@ -15,27 +15,24 @@ class DefinitionsLayer(object):
         self.sectional = False
         self.version = None
         self.rev_urls = utils.RegUrl()
+        self.rendered = {}
+        # precomputation 
+        for def_struct in self.layer['referenced'].values():
+            def_struct['reference_split'] = def_struct['reference'].split('-')
 
     def create_definition_link(self, original_text, citation):
         """ Create the link that takes you to the definition of the term. """
-
-        context = {
-            'citation': {
-                'url': self.rev_urls.fetch(citation, self.version,
+        key = (original_text, tuple(citation))
+        if key not in self.rendered:
+            context = {
+                'citation': {
+                    'url': self.rev_urls.fetch(citation, self.version,
                                            self.sectional),
-                'label': original_text,
-                'definition_reference': '-'.join(to_markup_id(citation))}}
-        return utils.render_template(self.citations_template, context)
-
-    def create_layer_pair(self, text, offset, layer_element):
-        """ Create a single layer pair. """
-        start, end = offset
-        ot = text[int(start):int(end)]
-        ref_in_layer = layer_element['ref']
-        def_struct = self.layer['referenced'][ref_in_layer]
-        definition_reference = def_struct['reference'].split('-')
-        rt = self.create_definition_link(ot, definition_reference)
-        return (ot, rt, (start, end))
+                    'label': original_text,
+                    'definition_reference': '-'.join(to_markup_id(citation))}}
+            rendered =  utils.render_template(self.citations_template, context)
+            self.rendered[key] = rendered
+        return self.rendered[key]
 
     def defined_terms(self, text, text_index):
         """Catch all terms which are defined elsewhere and replace them with
@@ -45,10 +42,12 @@ class DefinitionsLayer(object):
             layer_elements = self.layer[text_index]
 
             for layer_element in layer_elements:
-                for offset in layer_element['offsets']:
-                    layer_pair = self.create_layer_pair(
-                        text, offset, layer_element)
-                    layer_pairs.append(layer_pair)
+                ref = layer_element['ref']
+                ref = self.layer['referenced'][ref]['reference_split']
+                for start, end in layer_element['offsets']:
+                    ot = text[start:end]
+                    rt = self.create_definition_link(ot, ref)
+                    layer_pairs.append((ot, rt, (start, end)))
         return layer_pairs
 
     def defining_terms(self, text, text_index):

--- a/regserver/regulations/generator/layers/internal_citation.py
+++ b/regserver/regulations/generator/layers/internal_citation.py
@@ -13,15 +13,19 @@ class InternalCitationLayer():
         self.sectional = False
         self.version = None
         self.rev_urls = RegUrl()
+        self.rendered = {}
 
     def render_url(
         self, label, text,
             template_name='layers/internal_citation.html'):
 
-        url = self.rev_urls.fetch(label, self.version, self.sectional)
-        c = Context({'citation': {'url': url, 'label': text}})
-        template = loader.get_template(template_name)
-        return template.render(c).strip('\n')
+        key = (tuple(label), text, template_name)
+        if key not in self.rendered:
+            url = self.rev_urls.fetch(label, self.version, self.sectional)
+            c = Context({'citation': {'url': url, 'label': text}})
+            template = loader.get_template(template_name)
+            self.rendered[key] = template.render(c).strip('\n')
+        return self.rendered[key]
 
     def apply_layer(self, text, text_index):
         if text_index in self.layer:


### PR DESCRIPTION
We render the same definition and internal citations many times. Cache the results.

~9% improvement in Interp (building on #391)
