### PR TITLE
Performance Tweak 6: A few optimizations in frequent code

### DIFF
--- a/regserver/regulations/generator/layers/layers_applier.py
+++ b/regserver/regulations/generator/layers/layers_applier.py
@@ -63,12 +63,16 @@ class LayersApplier(object):
         """ Replace the occurrences of original at all the locations with replacement. """
 
         locations.sort()
-        htmlized = html.fragment_fromstring(self.text, create_parent='div')
-        self.location_replace(htmlized, original, replacement, locations)
-        self.text = html.tostring(htmlized)
-        self.text = self.text.replace("<div>", "", 1)
-        self.text = self.text[:self.text.rfind("</div>")]
-        self.unescape_text()
+        if '<' in self.text:
+            htmlized = html.fragment_fromstring(self.text, create_parent='div')
+            self.location_replace(htmlized, original, replacement, locations)
+            self.text = html.tostring(htmlized)
+            self.text = self.text.replace("<div>", "", 1)
+            self.text = self.text[:self.text.rfind("</div>")]
+            self.unescape_text()
+        else:
+            self.text = LocationReplace().location_replace_text(self.text,
+                original, replacement, locations)
 
     def apply_layers(self, original_text):
         self.text = original_text

--- a/regserver/regulations/generator/layers/location_replace.py
+++ b/regserver/regulations/generator/layers/location_replace.py
@@ -38,24 +38,28 @@ class LocationReplace(object):
         self.counter += 1
         return LocationReplace.replace_at_offset(offset, replacement, text)
 
+    def location_replace_text(self, text, original, replacement, locations):
+        """Given plain text, do replacements"""
+        self.update_offsets(original, text)
+
+        while (self.counter < len(locations)
+               and locations[self.counter] in self.offsets):
+            text = self.apply_layer_to_text(original, replacement, text,
+                                            locations)
+
+        self.update_offset_starter()
+        return text
+
     def location_replace(self, xml_node, original, replacement, locations):
         """ For the xml_node, replace the locations instances of orginal with replacement."""
 
         if xml_node.text:
-            self.update_offsets(original, xml_node.text)
-
-            while self.counter < len(locations) and locations[self.counter] in self.offsets:
-                xml_node.text = self.apply_layer_to_text(original, replacement, xml_node.text, locations)
-
-            self.update_offset_starter()
+            xml_node.text = self.location_replace_text(xml_node.text,
+                original, replacement, locations)
 
         for c in xml_node.getchildren():
             self.location_replace(c, original, replacement, locations)
 
         if xml_node.tail:
-            self.update_offsets(original, xml_node.tail)
-
-            while self.counter < len(locations) and locations[self.counter] in self.offsets:
-                xml_node.tail = self.apply_layer_to_text(original, replacement, xml_node.tail, locations)
-
-            self.update_offset_starter()
+            xml_node.tail = self.location_replace_text(xml_node.tail,
+                original, replacement, locations)


### PR DESCRIPTION
- Avoid creating a list when not needed
- Don't use html.fragment_fromstring in the outer-most layer application on a node

There's definitely room for improvement when applying layers; right now each node gets build into html and converted back into a string once per applicable layer. It's a messy operation though, and my attempts to speed it up failed miserably, so I'm content with this for now.

On Interp, ~6% speed up
