### PR TITLE
Performance Tweak 7: Don't build up XML nodes

### DIFF
--- a/regserver/regulations/tests/layers_location_replace_tests.py
+++ b/regserver/regulations/tests/layers_location_replace_tests.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+
+from regulations.generator.layers.location_replace import *
+
+
+class LayersLocationReplaceTest(TestCase):
+    def test_update_offsets_html(self):
+        lr = LocationReplace()
+        lr.update_offsets("a", "This is a test. It is only a test")
+        self.assertEqual(lr.offsets, {0: (8, 9), 1: (27, 28)})
+        lr.update_offsets("a", "This is a test. <a href='something'>link</a>")
+        self.assertEqual(lr.offsets, {0: (8, 9)})


### PR DESCRIPTION
One of the remaining slow points in our layer application was the need to build an XML node every time we applied a layer. As we have around a dozen layers and several thousand nodes, this was a bit of a bottleneck.

This patch applies the layers and avoids building up the XML by simply excluding text between angle brackets.

Also applied PEP8 fixes.

This is a ~50% improvement of page performance (using current master as a baseline).
