### PR TITLE
Make sure INS and DEL tags don't get escaped in interp titles

### DIFF
--- a/regserver/regulations/generator/templates/interp-tree.html
+++ b/regserver/regulations/generator/templates/interp-tree.html
@@ -3,9 +3,9 @@
 {% endcomment %}
 <section {% if not inline %}id="{{interp.markup_id}}"{% endif %}>
     {% if inline %}
-        <h5> {{ interp.header }}</h5>
+        <h5> {{ interp.header|safe }}</h5>
     {% elif interp.section_header %}
-        <h3 tabindex="0"> {{ interp.header }}</h3>
+        <h3 tabindex="0"> {{ interp.header|safe }}</h3>
     {% else %}
         <h4 class='interp-subheading' tabindex="0"> {{ interp.header_markup|safe }} </h4>
     {% endif %}


### PR DESCRIPTION
Not super elegant, but following suit with the changes to appendix and reg text headers
