### PR TITLE
Fix title case in search result headers

### DIFF
--- a/regserver/regulations/tests/views_partial_search_tests.py
+++ b/regserver/regulations/tests/views_partial_search_tests.py
@@ -17,7 +17,7 @@ class PartialSearchTest(TestCase):
         api_reader.ApiReader.return_value.search.return_value = {
             'total_hits': 3333,
             'results': [
-                {'label': ['111', '22'], 'text': 'tttt', 'version': 'vvv'},
+                {'label': ['111', '22'], 'text': 'tttt', 'version': 'vvv', 'title':"consumer's"},
                 {'label': ['111', '24', 'a'], 'text': 'o', 'version': 'vvv'},
                 {'label': ['111', '25'], 'text': 'more', 'version': 'vvv'}
             ]
@@ -39,6 +39,7 @@ class PartialSearchTest(TestCase):
         self.assertTrue('111-25' in response.content)
         self.assertTrue('111.25' in response.content)
         self.assertTrue('3333' in response.content)
+        self.assertTrue('Consumer&#39;s' in response.content)
 
 
     @patch('regulations.views.partial_search.api_reader')

--- a/regserver/regulations/views/partial_search.py
+++ b/regserver/regulations/views/partial_search.py
@@ -1,4 +1,5 @@
 from django.http import HttpResponseBadRequest
+from django.template.defaultfilters import title
 
 from regulations.generator import api_reader
 from regulations.generator.node_types import label_to_text
@@ -61,7 +62,7 @@ class PartialSearch(PartialView):
         for result in results['results']:
             result['header'] = label_to_text(result['label'])
             if 'title' in result:
-                result['header'] += ' ' + result['title'].title()
+                result['header'] += ' ' + title(result['title'])
             if 'Interp' in result['label']:
                 result['section_id'] = '%s-%s' % (result['label'][0],
                                                   'Interp')


### PR DESCRIPTION
Python's title() function does weird things. We use Django's instead which (for us) does the right thing. 
