### PR TITLE
Search through entire SxS section (regxml has some hierarchy issues)

### DIFF
--- a/regserver/regulations/generator/notices.py
+++ b/regserver/regulations/generator/notices.py
@@ -70,7 +70,7 @@ def find_label_in_sxs(sxs_list, label_id):
             if s['label'] == label_id:
                 if non_empty_sxs(s):
                     return s
-            elif s['children'] and label_id.startswith(s['label']):
+            elif s['children']:
                 sxs = find_label_in_sxs(s['children'], label_id)
                 if sxs and non_empty_sxs(sxs):
                     return sxs

--- a/regserver/regulations/tests/notices_tests.py
+++ b/regserver/regulations/tests/notices_tests.py
@@ -83,13 +83,17 @@ class NoticesTest(TestCase):
             {'label': '204-1', 'children': []},
             {'label': '204-2', 'children': [{
                 'label': '204-2-a',
-                'children': [],
+                'children': [
+                    {'label': '204-3', 'children': [], 'paragraphs': ['x']}],
                 'paragraphs': ['abc']}]}]
 
         s = notices.find_label_in_sxs(sxs_list, '204-2-a')
-        self.assertEqual({
-            'label': '204-2-a', 'children': [],
-            'paragraphs': ['abc']}, s)
+        self.assertEqual('204-2-a', s['label'])
+        self.assertEqual(['abc'], s['paragraphs'])
+
+        s = notices.find_label_in_sxs(sxs_list, '204-3')
+        self.assertEqual('204-3', s['label'])
+        self.assertEqual(['x'], s['paragraphs'])
 
     def test_non_empty_sxs(self):
         sxs = {'label': '204-2-a', 'children': [], 'paragraphs': ['abc']}


### PR DESCRIPTION
Unfortunately, FR XML doesn't deal with children correctly all the time (in this case, putting 33(b) as a child of 33(a). The long term fix might be to fix this in our notice representation, but as a stop gap, make sure to search through the entire SxS section to find a notice (prevents a 404).
