### PR TITLE
Do not track test.config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ _SpecRunner.html
 head/public/fonts
 regserver/regulations/static/regulations/docs/v/*/public/fonts/
 regserver/regulations/static/regulations/js/source/require.config.js
+regserver/regulations/static/regulations/js/tests/browser/test.config.js


### PR DESCRIPTION
This file gets created when one runs require.sh. It's meant to be ignored by git. 
