### PR TITLE
Account for diffs deeper in the tree

### DIFF
--- a/regulations/generator/layers/tree_builder.py
+++ b/regulations/generator/layers/tree_builder.py
@@ -39,13 +39,14 @@ def build_tree_hash(tree):
     have to keep walking the tree. """
     tree_hash = {}
 
-    if tree:
-        label_id = build_label(tree)
-        tree_hash[label_id] = tree
+    def per_node(node):
+        label_id = build_label(node)
+        tree_hash[label_id] = node
 
-        for c in tree['children']:
-            label_id = build_label(c)
-            tree_hash[label_id] = c
+        for c in node['children']:
+            per_node(c)
+    if tree:
+        per_node(tree)
     return tree_hash
 
 

--- a/regulations/tests/tree_builder_tests.py
+++ b/regulations/tests/tree_builder_tests.py
@@ -24,6 +24,19 @@ class TreeBuilderTest(TestCase):
         }
         return tree
 
+    def test_build_tree_hash(self):
+        tree = self.build_tree()
+        tree['children'][0]['children'] = [{
+            'text': 'child child test',
+            'children': [],
+            'label_id': '204-3-a',
+            'label': ['204', '3', 'a'],
+            'node_type': REGTEXT
+        }]
+        tree_hash = tree_builder.build_tree_hash(tree)
+        self.assertEqual(set(tree_hash.keys()),
+                         set(['204-3-a', '204-3', '204']))
+
     def test_parent_in_tree(self):
         tree = self.build_tree()
         tree_hash = tree_builder.build_tree_hash(tree)


### PR DESCRIPTION
@theresaanna found a bug when testing dummy data. This resolves by making sure all labels in the tree are accounted for.
