### PR TITLE
Allow headers to be nested deeper - useful for appendices

### DIFF
--- a/regulations/templates/regulations/tree.html
+++ b/regulations/templates/regulations/tree.html
@@ -1,6 +1,10 @@
 {% comment %}
     Template for inner paragraphs of a reg section
 {% endcomment %}
+{% if node.header %}
+<h{{ node.list_level|add:"+3" }}>{{ node.header | safe }}</h{{ node.list_level|add:"+3" }}>
+{% endif %}
+
 {%if node.marked_up %}
 <p> 
 {% if node.node_type == "appendix" %}


### PR DESCRIPTION
This won't affect pretty much anything except for appendices (as nothing else has headers buried so deep.)
