### PR TITLE
Fix ui test

### DIFF
--- a/regulations/uitests/interp_test.py
+++ b/regulations/uitests/interp_test.py
@@ -21,7 +21,7 @@ class InterpTest(BaseTest, unittest.TestCase):
         self.assertEquals(interp_dropdown.get_attribute('data-interp-id'), '1005-18-a')
 
         # should have the appropriate header
-        self.assertTrue('OFFICIAL INTERPRETATION TO 18' in interp_dropdown.text)
+        self.assertTrue('OFFICIAL INTERPRETATION TO 2(h)' in interp_dropdown.text)
 
         # body should be hidden
         interp_text = self.driver.find_element_by_xpath('//*[@id="1005-2-h"]/section/section')


### PR DESCRIPTION
Previously, we assumed the slide-down interpretations followed bad behavior (i.e. basing it on the interpretation's label). This worked until we had one interpretation for multiple sections.

With #497, this behavior was fixed, but the functional test wasn't touched. This commit updates the functional test to use the expected behavior.
