### PR TITLE
Remove unnecessary appendix markup

### DIFF
--- a/regulations/templates/regulations/appendix.html
+++ b/regulations/templates/regulations/appendix.html
@@ -11,9 +11,6 @@
             {% endwith %}
          {%endif%}
 
-         {{ c.marked_up|safe|linebreaksbr }}
-
-
             {% if c.marked_up %}
             <p> 
                 {{c.marked_up|safe|linebreaksbr}} 


### PR DESCRIPTION
The appendix markup was placing some content outside of the standard `<ol>` markup format. This attempts to simplify the markup and remedy that.

@khandelwal and @cmc333333 I'm a little foggy about whether I did this correctly. Could you please review closely and make suggestions as needed? Thanks!
