### PR TITLE
Add coverage metrics to python code

### DIFF
--- a/regulations/settings/dev.py
+++ b/regulations/settings/dev.py
@@ -15,6 +15,8 @@ INSTALLED_APPS += (
 )
 
 NOSE_ARGS = [
+    '--with-coverage',
+    '--cover-package=regulations',
     '--exclude-dir=regulations/uitests'
 ]
 


### PR DESCRIPTION
This aligns the travis tests with -parser and -core, printing coverage metrics. It doesn't include coveralls -- I'm not sure how to mix the JS and Python tests to get accurate metrics.
