### PR TITLE
Our label_to_text didn't take into account appendices with labels like M1, M2. 

### DIFF
--- a/regulations/generator/node_types.py
+++ b/regulations/generator/node_types.py
@@ -53,7 +53,8 @@ def _l2t_subterp(label):
     elif label[1:] == ['Appendices', 'Interp']:
         return 'Interpretations for Appendices of Part ' + label[0]
     elif len(label) == 4 and label[1] == 'Subpart' and label[3] == 'Interp':
-        return 'Interpretations for Subpart ' + label[2] + ' of Part ' + label[0]
+        interpretations_for = 'Interpretations for Subpart '
+        return interpretations_for + label[2] + ' of Part ' + label[0]
 
 
 def _l2t_interp(label):

--- a/regulations/tests/node_types_tests.py
+++ b/regulations/tests/node_types_tests.py
@@ -45,7 +45,8 @@ class NodeTypesTest(TestCase):
         self.assertEqual(u'§ 2323.1',
                          label_to_text(['2323', '1'], True, True))
         self.assertEqual(u'§ 1', label_to_text(['2323', '1'], False, True))
-        self.assertEqual('Appendix A to Part 2323', label_to_text(['2323', 'A']))
+        self.assertEqual(
+            'Appendix A to Part 2323', label_to_text(['2323', 'A']))
         self.assertEqual('Appendix A-4', label_to_text(['2323', 'A', '4']))
         self.assertEqual('Appendix A-4(b)(2)',
                          label_to_text(['2323', 'A', '4', 'b', '2']))
@@ -66,5 +67,5 @@ class NodeTypesTest(TestCase):
                          label_to_text(['204', 'Appendices', 'Interp']))
         self.assertEqual('This Section',
                          label_to_text(['204', 'Interp', 'h1']))
-
-        self.assertEqual('Appendix M2 to Part 204', label_to_text(['204', 'M2']))
+        self.assertEqual(
+            'Appendix M2 to Part 204', label_to_text(['204', 'M2']))


### PR DESCRIPTION
This is now fixed. 
