### PR TITLE
Account for SxS with a labels field

### DIFF
--- a/regulations/generator/notices.py
+++ b/regulations/generator/notices.py
@@ -66,7 +66,7 @@ def find_label_in_sxs(sxs_list, label_id):
     label_id. """
 
     for s in sxs_list:
-        if s.get('label') == label_id and non_empty_sxs(s):
+        if label_id in s.get('labels', [s.get('label')]) and non_empty_sxs(s):
             return s
         elif s['children']:
             sxs = find_label_in_sxs(s['children'], label_id)

--- a/regulations/tests/notices_tests.py
+++ b/regulations/tests/notices_tests.py
@@ -94,6 +94,22 @@ class NoticesTest(TestCase):
         self.assertEqual('204-3', s['label'])
         self.assertEqual(['x'], s['paragraphs'])
 
+        sxs_list = [
+            {'labels': ['204-1'], 'children': []},
+            {'labels': ['204-2'], 'children': [{
+                'labels': ['204-2-a', '204-2-b'],
+                'children': [
+                    {'labels': ['204-3'], 'children': [], 'paragraphs': ['x']}],
+                'paragraphs': ['abc']}]}]
+
+        s = notices.find_label_in_sxs(sxs_list, '204-2-b')
+        self.assertEqual(['204-2-a', '204-2-b'], s['labels'])
+        self.assertEqual(['abc'], s['paragraphs'])
+
+        s = notices.find_label_in_sxs(sxs_list, '204-3')
+        self.assertEqual(['204-3'], s['labels'])
+        self.assertEqual(['x'], s['paragraphs'])
+
     def test_find_label_in_sxs_top_no_label(self):
         sxs_list = [
             {'title': 'Awesome, SXS title here', 'children': [
@@ -102,6 +118,15 @@ class NoticesTest(TestCase):
 
         s = notices.find_label_in_sxs(sxs_list, '204-3')
         self.assertEqual('204-3', s['label'])
+        self.assertEqual(['x'], s['paragraphs'])
+
+        sxs_list = [
+            {'title': 'Awesome, SXS title here', 'children': [
+                {'labels': ['204-3'], 'children': [], 'paragraphs': ['x']}],
+                'paragraphs': ['abc']}]
+
+        s = notices.find_label_in_sxs(sxs_list, '204-3')
+        self.assertEqual(['204-3'], s['labels'])
         self.assertEqual(['x'], s['paragraphs'])
 
     def test_non_empty_sxs(self):


### PR DESCRIPTION
To account for duplicate labels, we used to copy the SxS. Now, we'll be adding a field which is a list of labels.

This patch works with both that strategy ("labels") as well as the old data, ("label").
