### PR TITLE
Template expects a label field, even when that might not be present

### DIFF
--- a/regulations/tests/views_sxs_tests.py
+++ b/regulations/tests/views_sxs_tests.py
@@ -100,3 +100,18 @@ class ParagrasphSXSViewTests(TestCase):
                          sxs['paragraphs'][2])
         self.assertEqual('Subparagraph[22] here',
                          sxs['children'][0]['paragraphs'][0])
+
+    @patch('regulations.views.partial_sxs.generator')
+    @patch('regulations.views.partial_sxs.notices')
+    @patch.object(ParagraphSXSView, 'further_analyses')
+    def test_get_context_data(self, further_analyses, notices, generator):
+        psv = ParagraphSXSView()
+        generator.get_sxs.return_value = {
+            'labels': ['lablab', 'another-label'],
+            'children': [],
+            'paragraphs': ['some', 'content']
+        }
+        context = psv.get_context_data(label_id='lablab', notice_id='nnnn',
+                                       version='vvv')
+        self.assertTrue('sxs' in context)
+        self.assertTrue('label' in context['sxs'])

--- a/regulations/views/partial_sxs.py
+++ b/regulations/views/partial_sxs.py
@@ -116,6 +116,8 @@ class ParagraphSXSView(TemplateView):
         self.footnote_refs(paragraph_sxs)
 
         context['sxs'] = paragraph_sxs
+        # Template assumes a single label
+        context['sxs']['label'] = context['label_id']
         context['sxs']['header'] = label_to_text(label_id.split('-'),
                                                  include_marker=True)
         context['sxs']['all_footnotes'] = self.footnotes(notice, paragraph_sxs)


### PR DESCRIPTION
Fixes a bug introduced with #627, where the chrome of a SxS wasn't displaying.
