### PR TITLE
Add missing definition section

### DIFF
--- a/regulations/templates/regulations/generic_landing.html
+++ b/regulations/templates/regulations/generic_landing.html
@@ -19,6 +19,7 @@
 
 <div id="sidebar" class="secondary-content">
     <div id="sidebar-content" class="sidebar-inner">
+    <section id="definition"></section>
     <section class="landing-sidebar">
         {% if new_version %}
         <div class="alert">


### PR DESCRIPTION
If you're using a modern browser (with push state) and you begin from a reg landing page, the "section#definition" wasn't present for definition to load into once you navigated to the reg.

This adds said section.
