### PR TITLE
Account for reserved subparts, which don't have children

### DIFF
--- a/regulations/generator/toc.py
+++ b/regulations/generator/toc.py
@@ -59,7 +59,7 @@ def toc_subpart(data, so_far, toc):
         'is_subpart': True,
         'sub_toc': []
     }
-    for sub in toc['-'.join(data['index'])]:
+    for sub in toc.get('-'.join(data['index']), []):
         element['sub_toc'].append(toc_sect_appendix(sub, so_far))
     return element
 

--- a/regulations/tests/generator_toc_tests.py
+++ b/regulations/tests/generator_toc_tests.py
@@ -60,6 +60,20 @@ class TocTest(TestCase):
         self.assertEqual('Other', s2['sub_label'])
         self.assertEqual(['1001', '2'], s2['index'])
 
+    def test_toc_subpart_reserved(self):
+        layer = {'1001-Subpart-A': [{'title': '1001.1 - Content',
+                                     'index': ['1001', '1']},
+                                    {'title': '1001.2 - Other',
+                                     'index': ['1001', '2']}]}
+        data = {'title': u'[Reserved]', 'index': ['1001', 'Subpart', 'B']}
+        result = toc.toc_subpart(data, [], layer)
+        self.assertEqual('Subpart B', result['label'])
+        self.assertEqual('[Reserved]', result['sub_label'])
+        self.assertEqual(['1001', 'Subpart', 'B'], result['index'])
+        self.assertEqual('1001-Subpart-B', result['section_id'])
+        self.assertTrue(result.get('is_subpart'))
+        self.assertEqual(0, len(result['sub_toc']))
+
     def test_toc_interp(self):
         so_far = [
             {'index': ['1001', '1']},


### PR DESCRIPTION
Ran into a reg with a reserved subpart, which meant that it didn't have children. As a result, it didn't have a  TOC entry, which caused this to fail.

Solution of using an empty list makes the entry still appear in the TOC, just without children.
