### PR TITLE
point to new documentation url

### DIFF
--- a/regulations/templates/regulations/about.html
+++ b/regulations/templates/regulations/about.html
@@ -9,7 +9,7 @@
 {% block body %}
 
 <header id="site-header" class="reg-header">
-    {% include "regulations/main-header.html" %} 
+    {% include "regulations/main-header.html" %}
 </header>
 
 <div class="about-content wrap">
@@ -32,7 +32,7 @@
         <div class="content-secondary column-r well dev-well">
             <span class="minicon-octocat"></span><span class="icon-text">Github</span>
             <h4>Developers</h4>
-            <p>eRegulations is an open source project. Visit <a href="http://eregs.github.io/eregulations/" class="external" target="_blank">the project repository</a> to learn more and contribute.</p>
+            <p>eRegulations is an open source project. Visit <a href="http://cfpb.github.io/eRegulations/" class="external" target="_blank">the project repository</a> to learn more and contribute.</p>
         </div>
     </div>
     <div id="read" class="inner-wrap easy-read group">
@@ -144,7 +144,7 @@
                 take you to the notice on the Office of the Federal Register’s website.</li>
                 <li><strong>Compare</strong> any two revisions of the regulation, word for word, by selecting a date in the menu.</li>
             </ol>
-            
+
             <img src="{%static "regulations/img/regtimeline-02.png" %}" alt="eRegulations revision comparison screenshot">
         </div>
     </div>
@@ -153,6 +153,6 @@
 
 </div>
 
-{% include "regulations/full_footer.html" %} 
+{% include "regulations/full_footer.html" %}
 
 {% endblock %}


### PR DESCRIPTION
This points the about page link to http://cfpb.github.io/eRegulations/.

Also, my text editor is configured to remove trailing white space on save, which you can see in the diff.
 ¯\_(ツ)_/¯
