### PR TITLE
add cell borders

### DIFF
--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -524,9 +524,11 @@ tbody > tr:nth-child(odd){
 }
 
 /* make tables horizontally scroll on small screens */
-.table-wrap {
-    overflow-y: scroll;
-    -webkit-overflow-scrolling: touch; // smoother scrolling
+@media only screen and ( max-width: 480px ) {
+    .table-wrap {
+        overflow-y: scroll;
+        -webkit-overflow-scrolling: touch; // smoother scrolling
+    }
 }
 
 /*

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -495,7 +495,7 @@ th,
 td {
     padding: 15px;
     line-height: 20px;
-    border: 0;
+    border: 1px solid @80_gray;
 }
 
 thead {
@@ -520,7 +520,7 @@ tr {
 }
 
 tbody > tr:nth-child(odd){
-    background: #F1F2F2; /* grey-10% */
+    background: #FFFFFF;
 }
 
 /* make tables horizontally scroll on small screens */


### PR DESCRIPTION
This adds borders around the table cells to make the tables in the tool be closer in appearance to the originals.

![screen shot 2015-04-10 at 4 21 52 pm](https://cloud.githubusercontent.com/assets/212533/7096747/2af95036-df9e-11e4-9fbc-0a6a063aeaed.png)




