### PR TITLE
remove styling to tables to match reg

### DIFF
--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -486,7 +486,6 @@ table {
     padding: 0;
     font-size: .75em;
     .avenir-next;
-    background: #F8F8F8;
     table-layout: fixed;
     width: 100%;
 }
@@ -498,29 +497,11 @@ td {
     border: 1px solid @80_gray;
 }
 
-thead {
-    background: #515355; /* dark-grey */
-}
-
-thead th,
-thead td {
-    color: #ffffff;
-    background: #515355; /* dark-grey */
-}
-
 th {
     font-family: "Avenir Next Demi", Arial, sans-serif;
     font-weight: 600;
     font-style: normal;
     text-align: left;
-}
-
-tr {
-    background: #F8F8F8; /* grey-05% */
-}
-
-tbody > tr:nth-child(odd){
-    background: #FFFFFF;
 }
 
 /* make tables horizontally scroll on small screens */


### PR DESCRIPTION
This makes the table styles **very** minimal so that they closely mirror the tables that are present in CFPB regulations.
![screen shot 2015-04-28 at 4 20 43 pm](https://cloud.githubusercontent.com/assets/212533/7379399/9f830b54-edc2-11e4-8ff8-e66e91ed657a.png)
