### PR TITLE
Remove old style analytics

### DIFF
--- a/regulations/static/regulations/js/source/regulations.js
+++ b/regulations/static/regulations/js/source/regulations.js
@@ -1,7 +1,7 @@
 // Launches app
 'use strict';
-var $ = require('jquery');
-global.jQuery = require('jquery'); // make jQuery globally accessible for plugins and analytics
+// make jQuery globally accessible for plugins and analytics
+global.$ = global.jQuery = require('jquery');
 var app = require('./app-init');
 
 // A `bind()` polyfill

--- a/regulations/templates/regulations/base.html
+++ b/regulations/templates/regulations/base.html
@@ -46,17 +46,6 @@ CSS/Javascript etc., should inherit from this template.
     <!--[if IE 9]>         <body class="lt-ie10"> <![endif]-->
     <!--[if gt IE 9]><!--><body><!--<![endif]-->
     {% if EREGS_GA_EREGS_SITE and EREGS_GA_EREGS_ID %}
-        <!-- Old style analytics -->
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-          ga('create',
-              '{{ EREGS_GA_EREGS_ID }}', '{{ EREGS_GA_EREGS_SITE }}');
-          ga('send', 'pageview');
-        </script>
         <!-- Google Tag Manager -->
           <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
           height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -69,11 +58,5 @@ CSS/Javascript etc., should inherit from this template.
     {% endif %}
     {% block body %}
     {% endblock %}
-    {% if EREGS_GA_ALT_SITE and EREGS_GA_ALT_ID %}
-        <script>
-            ga('create', '{{ EREGS_GA_ALT_ID }}', '{{ EREGS_GA_ALT_SITE }}', {'name': 'altAcct'});
-            ga('altAcct.send', 'pageview');
-        </script>
-    {% endif %}
     </body>
 </html>


### PR DESCRIPTION
We were given the go ahead to test out only using Google tag manager. This should greatly reduce the number of requests as we were sending data to three different analytics accounts.

This also makes sure that jQuery is globally accessible as both `jQuery` and `$` for our tag manager code.