### PR TITLE
add uglify to default Grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -183,5 +183,5 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['eslint', 'mocha_istanbul', 'nose']);
   grunt.registerTask('build', ['squish', 'test']);
   grunt.registerTask('squish', ['browserify', 'uglify', 'less:dist']);
-  grunt.registerTask('default', ['browserify', 'less']);
+  grunt.registerTask('default', ['browserify', 'less', 'uglify']);
 };


### PR DESCRIPTION
This adds uglify to the default grunt task so that someone has a working version of the site after running `grunt` whether debug mode is set to true or false.