### PR TITLE
Breakaway view improvements

### DIFF
--- a/regulations/static/regulations/css/less/module/sxs.less
+++ b/regulations/static/regulations/css/less/module/sxs.less
@@ -8,7 +8,7 @@ sxs.less contains styles for the SxS overlay
     #breakaway-view {
         position: fixed;
         left: 9999px;
-        .slide (@direction: all, @speed: 800ms);
+        .slide (@direction: all, @speed: 600ms);
     }
 }
 
@@ -22,7 +22,7 @@ SxS window
     position: fixed;
     left: 0;
     width: 100%;
-    height: 100%; 
+    height: 100%;
     min-height: 100%;
     background: #fff;
     z-index: 9999;
@@ -112,7 +112,7 @@ SxS content wrapper
     }
 }
 
-/* 
+/*
 Main content of the SxS Analysis
 ================================
 */
@@ -123,7 +123,7 @@ Main content of the SxS Analysis
     padding-bottom: 100px;
 }
 
-/* 
+/*
 Metadata info for the SxS Analysis
 ==================================
 */
@@ -179,7 +179,7 @@ Metadata info for the SxS Analysis
     }
 }
 
-/* 
+/*
 Footnotes
 ==================================
 */

--- a/regulations/static/regulations/js/source/views/breakaway/sxs-view.js
+++ b/regulations/static/regulations/js/source/views/breakaway/sxs-view.js
@@ -22,6 +22,9 @@ var SxSView = Backbone.View.extend({
         var render;
         this.externalEvents = BreakawayEvents;
 
+        // visibly open the SxS panel immediately
+        this.$el.addClass('open-sxs');
+
         // callback to be sent to model's get method
         // called after ajax resolves sucessfully
         render = function(success, returned) {
@@ -31,8 +34,6 @@ var SxSView = Backbone.View.extend({
             else {
                 this.render('<div class="error"><span class="cf-icon cf-icon-error icon-warning"></span>Due to a network error, we were unable to retrieve the requested information.</div>');
             }
-
-            this.$el.addClass('open-sxs');
         }.bind(this);
 
         SxSModel.get(this.options.url, render),

--- a/regulations/templates/regulations/paragraph-sxs.html
+++ b/regulations/templates/regulations/paragraph-sxs.html
@@ -1,6 +1,6 @@
 {% if sxs.label %}
     <div class="sxs-header">
-        <a class="sxs-back-button" href="{{ back_url }}"><span class="cf-icon cf-icon-left"></span> {{sxs.header}}</a>
+        <a class="sxs-back-button" href="{{ back_url }}"><span class="cf-icon cf-icon-arrow-left-round"></span> {{sxs.header}}</a>
         <h2><span class="sxs-label">Section-by-section analysis - </span>{{ notice.fr_volume }} FR {{ sxs.page }}</h2>
     </div>
     <div class="sxs-content group">
@@ -70,13 +70,13 @@
             <h3>Further Analysis:</h3>
             <ul class="analysis-list">
             {% for analysis in further_analyses %}
-                <li><a 
-                    href="{% url 'chrome_sxs_view' analysis.reference.1 analysis.reference.0 %}?from_version={{version}}&fr_page={{analysis.fr_page}}" 
+                <li><a
+                    href="{% url 'chrome_sxs_view' analysis.reference.1 analysis.reference.0 %}?from_version={{version}}&fr_page={{analysis.fr_page}}"
                     data-sxs-pararaph-id="{{analysis.reference.1}}"
                     data-doc-number="{{analysis.reference.0}}"
                     class="internal"
                     >{{ analysis.fr_volume }} FR {{ analysis.fr_page }}</a>
-                    <br />Published {{ analysis.publication_date|date:"F j, Y" }} 
+                    <br />Published {{ analysis.publication_date|date:"F j, Y" }}
                 </li>
             {% endfor %}
             </ul>
@@ -90,4 +90,3 @@
 {% if sxs.label %}
     </div>
 {% endif %}
-


### PR DESCRIPTION
This makes a few minor adjustments to the breakaway view aka Section by Section analysis:

- Begins to slide open the panel before the Ajax request is resolved (note: this load happens really fast so I didn't implement any sort of loading transition for the text. We may want to add a transition state or a loading spinner if this becomes noticeable)
- Replaces the back caret with a back arrow as designed by @jehlers way back int the day

## Review

@KimberlyMunoz do you mind doing the honors?