### PR TITLE
Prevent hard refresh when clicking a sub definition

### DIFF
--- a/regulations/static/regulations/js/source/views/sidebar/definition-view.js
+++ b/regulations/static/regulations/js/source/views/sidebar/definition-view.js
@@ -51,6 +51,7 @@ var DefinitionView = SidebarModuleView.extend({
         if (Router.hasPushState) {
             this.events['click .continue-link.interp'] = 'openInterpretation';
             this.events['click .continue-link.full-def'] = 'openFullDefinition';
+            this.events['click .definition'] = 'openFullDefinition';
             this.delegateEvents(this.events);
         }
     },
@@ -156,7 +157,7 @@ var DefinitionView = SidebarModuleView.extend({
 
     openFullDefinition: function(e) {
         e.preventDefault();
-        var id = this.id || $(e.target).data('linked-section'),
+        var id = $(e.target).data('linked-section') || $(e.target).data('definition'),
             parentId = Helpers.findBaseSection(id);
 
         MainEvents.trigger('section:open', parentId, {


### PR DESCRIPTION
Previously, when clicking a definition within the definition sidebar pane, the browser would do a hard page load. This caused the existing definition window to close. Now, these "sub definitions" will load using push state (when available).

## Before
![screen shot 2015-06-04 at 11 59 23 am](https://cloud.githubusercontent.com/assets/212533/7988468/9e78b63a-0ab1-11e5-818a-6b899d026b4f.png)

:arrow_down: 

![screen shot 2015-06-04 at 11 59 39 am](https://cloud.githubusercontent.com/assets/212533/7988474/a40d0830-0ab1-11e5-8a8a-3f4c2b290911.png)

:confounded: 

## After

![screen shot 2015-06-04 at 12 00 11 pm](https://cloud.githubusercontent.com/assets/212533/7988484/a9b4a50e-0ab1-11e5-8298-cbde477ad36e.png)

:arrow_down: 

![screen shot 2015-06-04 at 12 00 19 pm](https://cloud.githubusercontent.com/assets/212533/7988487/ae19b710-0ab1-11e5-8c45-497887289ce6.png)

:smiley:


## Review

@KimberlyMunoz 