### PR TITLE
Add the dash layer formatting and associated templates and style

### DIFF
--- a/regulations/generator/layers/formatting.py
+++ b/regulations/generator/layers/formatting.py
@@ -47,11 +47,6 @@ class FormattingLayer(object):
         context = Context({'lines': lines})
         return self.code_tpl.render(context)
 
-    def render_dash(self, dash_data):
-        text = dash_data.get('text')
-        context = Context({'text': text})
-        return self.dash_tpl.render(context).replace('\n', '')
-
     def apply_layer(self, text_index):
         """Convert all plaintext tables into html tables"""
         layer_pairs = []

--- a/regulations/generator/layers/formatting.py
+++ b/regulations/generator/layers/formatting.py
@@ -14,6 +14,7 @@ class FormattingLayer(object):
         self.code_tpl = loader.get_template('regulations/layers/code.html')
         self.subscript_tpl = loader.get_template(
             'regulations/layers/subscript.html')
+        self.dash_tpl = loader.get_template('regulations/layers/dash.html')
 
     def render_table(self, table):
         max_width = 0
@@ -46,6 +47,11 @@ class FormattingLayer(object):
         context = Context({'lines': lines})
         return self.code_tpl.render(context)
 
+    def render_dash(self, dash_data):
+        text = dash_data.get('text')
+        context = Context({'text': text})
+        return self.dash_tpl.render(context).replace('\n', '')
+
     def apply_layer(self, text_index):
         """Convert all plaintext tables into html tables"""
         layer_pairs = []
@@ -55,6 +61,7 @@ class FormattingLayer(object):
                     layer_pairs.append((data['text'],
                                         self.render_table(data['table_data']),
                                         data['locations']))
+
                 if data.get('fence_data', {}).get('type') == 'note':
                     layer_pairs.append((data['text'],
                                         self.render_note(data['fence_data']),
@@ -63,11 +70,20 @@ class FormattingLayer(object):
                     layer_pairs.append((data['text'],
                                         self.render_code(data['fence_data']),
                                         data['locations']))
+
                 if 'subscript_data' in data:
                     layer_pairs.append((
                         data['text'],
                         self.subscript_tpl.render(Context(
                             data['subscript_data'])).replace('\n', ''),
                         data['locations']))
+
+                if 'dash_data' in data:
+                    layer_pairs.append(
+                            (data['text'], 
+                             self.dash_tpl.render(
+                                    Context(data['dash_data'])
+                                ).replace('\n', ''),
+                             data['locations']))
 
         return layer_pairs

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -478,6 +478,36 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqu
     line-height: 1.4;
 }
 
+.model-form-dash {
+    position: relative;
+    overflow: hidden;
+    display: inline-block;
+    width: 100%;
+    
+    span {
+        display: inline-block;
+        vertical-align: baseline;
+        zoom: 1;
+        *display: inline;
+        *vertical-align: auto;
+        position: relative;
+        padding-right: 0.4em;
+
+        &:after {
+            content: '';
+            display: block;
+            width: 1000px;
+            position: absolute;
+            top: 1.2em;
+            border-top: 1px solid @black;
+        }
+
+        &:after { left: 100%; }
+    }
+}
+
+
+
 /*
   Table Styles
  ========================================================================== */

--- a/regulations/templates/regulations/layers/dash.html
+++ b/regulations/templates/regulations/layers/dash.html
@@ -1,0 +1,4 @@
+{% comment %}
+  Paragraph that fills out with dashes for appendices
+{% endcomment %}
+<span class="model-form-dash"><span>{{ text }}</span></span>

--- a/regulations/tests/layers_formatting_tests.py
+++ b/regulations/tests/layers_formatting_tests.py
@@ -34,16 +34,9 @@ class FormattingLayerTest(TestCase):
 
     @patch('regulations.generator.layers.formatting.loader')
     def test_apply_layer_note(self, loader):
-        mocks = {'table': Mock(), 'note': Mock(), 'code': Mock(),
-                 'subscript': Mock(), 'dash': Mock()}
-
-        def ret_mock(arg):
-            for key in mocks:
-                if key in arg:
-                    return mocks[key]
-
-        loader.get_template.side_effect = ret_mock
-        render = mocks['note'].render
+        note_mock = Mock()
+        loader.get_template.side_effect = lambda arg: note_mock if "note" in arg else Mock()
+        render = note_mock.render
 
         fence_data = {'type': 'note',
                       'lines': ['Note:', '1. Content1', '2. Content2']}
@@ -68,16 +61,9 @@ class FormattingLayerTest(TestCase):
 
     @patch('regulations.generator.layers.formatting.loader')
     def test_apply_layer_code(self, loader):
-        mocks = {'table': Mock(), 'note': Mock(), 'code': Mock(),
-                 'subscript': Mock(), 'dash': Mock()}
-
-        def ret_mock(arg):
-            for key in mocks:
-                if key in arg:
-                    return mocks[key]
-
-        loader.get_template.side_effect = ret_mock
-        render = mocks['code'].render
+        code_mock = Mock()
+        loader.get_template.side_effect = lambda arg: code_mock if "code" in arg else Mock()
+        render = code_mock.render
 
         fence_data = {'type': 'python',
                       'lines': ['def double(x):', '    return x + x']}
@@ -102,16 +88,9 @@ class FormattingLayerTest(TestCase):
 
     @patch('regulations.generator.layers.formatting.loader')
     def test_apply_layer_subscript(self, loader):
-        mocks = {'table': Mock(), 'note': Mock(), 'code': Mock(),
-                 'subscript': Mock(), 'dash': Mock()}
-
-        def ret_mock(arg):
-            for key in mocks:
-                if key in arg:
-                    return mocks[key]
-
-        loader.get_template.side_effect = ret_mock
-        render = mocks['subscript'].render
+        subscript_mock = Mock()
+        loader.get_template.side_effect = lambda arg: subscript_mock if "subscript" in arg else Mock()
+        render = subscript_mock.render
 
         subscript_data = {'variable': 'abc', 'subscript': '123'}
         data = {'111-1': [],
@@ -136,16 +115,9 @@ class FormattingLayerTest(TestCase):
 
     @patch('regulations.generator.layers.formatting.loader')
     def test_apply_layer_dash(self, loader):
-        mocks = {'table': Mock(), 'note': Mock(), 'code': Mock(),
-                 'subscript': Mock(), 'dash': Mock()}
-
-        def ret_mock(arg):
-            for key in mocks:
-                if key in arg:
-                    return mocks[key]
-
-        loader.get_template.side_effect = ret_mock
-        render = mocks['dash'].render
+        dash_mock = Mock()
+        loader.get_template.side_effect = lambda arg: dash_mock if "dash" in arg else Mock()
+        render = dash_mock.render
 
         dash_data = {'text': 'This is an fp-dash'}
         data = {'111-1': [],

--- a/regulations/tests/layers_formatting_tests.py
+++ b/regulations/tests/layers_formatting_tests.py
@@ -35,7 +35,7 @@ class FormattingLayerTest(TestCase):
     @patch('regulations.generator.layers.formatting.loader')
     def test_apply_layer_note(self, loader):
         mocks = {'table': Mock(), 'note': Mock(), 'code': Mock(),
-                 'subscript': Mock()}
+                 'subscript': Mock(), 'dash': Mock()}
 
         def ret_mock(arg):
             for key in mocks:
@@ -69,7 +69,7 @@ class FormattingLayerTest(TestCase):
     @patch('regulations.generator.layers.formatting.loader')
     def test_apply_layer_code(self, loader):
         mocks = {'table': Mock(), 'note': Mock(), 'code': Mock(),
-                 'subscript': Mock()}
+                 'subscript': Mock(), 'dash': Mock()}
 
         def ret_mock(arg):
             for key in mocks:
@@ -103,7 +103,7 @@ class FormattingLayerTest(TestCase):
     @patch('regulations.generator.layers.formatting.loader')
     def test_apply_layer_subscript(self, loader):
         mocks = {'table': Mock(), 'note': Mock(), 'code': Mock(),
-                 'subscript': Mock()}
+                 'subscript': Mock(), 'dash': Mock()}
 
         def ret_mock(arg):
             for key in mocks:
@@ -132,3 +132,36 @@ class FormattingLayerTest(TestCase):
         context = render.call_args[0][0]
         self.assertEqual(context['variable'], 'abc')
         self.assertEqual(context['subscript'], '123')
+
+
+    @patch('regulations.generator.layers.formatting.loader')
+    def test_apply_layer_dash(self, loader):
+        mocks = {'table': Mock(), 'note': Mock(), 'code': Mock(),
+                 'subscript': Mock(), 'dash': Mock()}
+
+        def ret_mock(arg):
+            for key in mocks:
+                if key in arg:
+                    return mocks[key]
+
+        loader.get_template.side_effect = ret_mock
+        render = mocks['dash'].render
+
+        dash_data = {'text': 'This is an fp-dash'}
+        data = {'111-1': [],
+                '111-2': [{}],
+                '111-3': [{'text': 'This is an fp-dash_____', 'locations': [0],
+                           'dash_data': dash_data}]}
+        fl = FormattingLayer(data)
+        self.assertEqual([], fl.apply_layer('111-0'))
+        self.assertEqual([], fl.apply_layer('111-1'))
+        self.assertEqual([], fl.apply_layer('111-2'))
+        self.assertFalse(render.called)
+
+        result = fl.apply_layer('111-3')
+        self.assertEqual(len(result), 1)
+        self.assertEqual('This is an fp-dash_____', result[0][0])
+        self.assertEqual([0], result[0][2])
+        self.assertTrue(render.called)
+        context = render.call_args[0][0]
+        self.assertEqual(context['text'], 'This is an fp-dash')


### PR DESCRIPTION
This PR handles the JSON created in cfpb/regulations-parser#276 for elements in the regulation XML like this:

```xml
<FP SOURCE="FP-DASH">Developer's Name</FP>
```
In the regulation XML. These are ["paragraphs that fill with dashes"](http://www.gpo.gov/fdsys/bulkdata/CFR/resources/CFR-XML_User-Guide_v1.pdf) and are used in regulations for model forms. 

This adds code to handle the `FP-DASH` paragraphs in in the formatting layer, as well as a template for rendering them and styles to create the "dash" (in this case, an underline) that extends after the text to the end of the line.

The result appears like this:

![image](https://cloud.githubusercontent.com/assets/10562538/8094849/89e03866-0f97-11e5-8565-cf0b04baffbe.png)

This PR goes along with cfpb/regulations-parser#276.

@ascott1 
@grapesmoker 