### PR TITLE
`projectegg` is deprecated in djangorecipe 2.0 (fixes failing buildout)

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -14,7 +14,6 @@ eggs = ${buildout:eggs}
 [django]
 recipe = djangorecipe
 project = regulations
-projectegg = regulations
 settings = settings.dev
 test = regulations
 eggs = ${buildout:eggs}


### PR DESCRIPTION
This PR removes the `projectegg` line from `buildout.cfg`. This was causing buildout to fail (for anyone building regulations-site and for Travis).