### PR TITLE
Lint js and run js unit tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
     - bower install
     - cp example-config.json config.json
 script:
+    - grunt test-js
     - ./bin/test
     - ./dummy_api/start.sh
     - echo 'API_BASE = "http://localhost:8282/"' >> regulations/settings/local_settings.py


### PR DESCRIPTION
This adds the `grunt test-js` task to Travis, so that our JavaScript unit tests and linter are run on pull requests.

Review @willbarton 