### PR TITLE
add script area to about page template

### DIFF
--- a/regulations/templates/regulations/about.html
+++ b/regulations/templates/regulations/about.html
@@ -155,4 +155,6 @@
 
 {% include "regulations/full_footer.html" %}
 
+{% block endscripts %}
+{% endblock %}
 {% endblock %}


### PR DESCRIPTION
Adds a block for `<script>` tags on the about page, similar to the generic universal landing page. This is needed to fix #729.