### PR TITLE
Add loading indicator for Section by Section analysis, closes #725

### DIFF
--- a/regulations/static/regulations/css/less/main.less
+++ b/regulations/static/regulations/css/less/main.less
@@ -9,9 +9,9 @@ and includes any non-semantic helper classes
 Type & Layout
 ------------- */
 @import "normalize.less";
+@import "cf-icons.less";
 @import "mixins.less";
 @import "fonts.less";
-@import "cf-icons.less";
 @import "typography.less";
 @import "layout.less";
 

--- a/regulations/static/regulations/css/less/main.less
+++ b/regulations/static/regulations/css/less/main.less
@@ -102,17 +102,7 @@ Modules
 }
 
 .loading-spinner:after {
-    .cf-icon;
-    .cf-icon__spin;
-    display: block;
-    width: 1em;
-    height: 1em;
-    margin: 0 auto;
-    content: "\e112";
-    color: @pacific;
-    text-align: center;
-    font-size: 1.375em;
-    margin-top: 2em;
+    .spinner;
 }
 
 .important {

--- a/regulations/static/regulations/css/less/mixins.less
+++ b/regulations/static/regulations/css/less/mixins.less
@@ -101,6 +101,20 @@ mixins.less contains any mixins or variables to be used throughout the LESS file
             transition: @direction @speed ease;
 }
 
+.spinner {
+    .cf-icon;
+    .cf-icon__spin;
+    display: block;
+    width: 1em;
+    height: 1em;
+    margin: 0 auto;
+    content: "\e112";
+    color: @pacific;
+    text-align: center;
+    font-size: 1.375em;
+    margin-top: 2em;
+}
+
  /*
  Helpers
  ------------- */

--- a/regulations/static/regulations/css/less/module/sxs.less
+++ b/regulations/static/regulations/css/less/module/sxs.less
@@ -34,6 +34,20 @@ SxS window
     top: 60px;
 }
 
+.inprogress {
+    .cf-icon;
+    .cf-icon__spin;
+    display: block;
+    width: 1em;
+    height: 1em;
+    margin: 0 auto;
+    content: "\e112";
+    color: @pacific;
+    text-align: center;
+    font-size: 1.375em;
+    margin-top: 2em;
+}
+
 /*
 SxS header
 ===================

--- a/regulations/static/regulations/css/less/module/sxs.less
+++ b/regulations/static/regulations/css/less/module/sxs.less
@@ -35,17 +35,7 @@ SxS window
 }
 
 .inprogress {
-    .cf-icon;
-    .cf-icon__spin;
-    display: block;
-    width: 1em;
-    height: 1em;
-    margin: 0 auto;
-    content: "\e112";
-    color: @pacific;
-    text-align: center;
-    font-size: 1.375em;
-    margin-top: 2em;
+  .spinner;
 }
 
 /*

--- a/regulations/static/regulations/js/source/views/breakaway/sxs-view.js
+++ b/regulations/static/regulations/js/source/views/breakaway/sxs-view.js
@@ -25,9 +25,13 @@ var SxSView = Backbone.View.extend({
         // visibly open the SxS panel immediately
         this.$el.addClass('open-sxs');
 
+        // give it a state of `progress` until content loads
+        this.changeState('inprogress');
+
         // callback to be sent to model's get method
         // called after ajax resolves sucessfully
         render = function(success, returned) {
+            this.changeState('completed');
             if (success) {
                 this.render(returned);
             }
@@ -49,6 +53,13 @@ var SxSView = Backbone.View.extend({
 
     render: function(analysis) {
         this.$el.html(analysis);
+    },
+
+    changeState: function(state) {
+        // if a previous state exists remove the class before updating
+        this.$el.removeClass(this.loadingState);
+        this.loadingState = state;
+        this.$el.addClass(state);
     },
 
     footnoteHighlight: function(e) {


### PR DESCRIPTION
#722 changed the way the SxS breakaway view is loaded to animate before the content is loaded. That means that when content is loaded slowly, the user stares at a semi-blank screen while waiting for the request to finish. This adds a little spinning indicator in those scenarios.

![spinning](https://cloud.githubusercontent.com/assets/212533/8290959/454982be-18f4-11e5-84e7-c35a33fc37dd.gif)

It's not beautiful, but it's rare that this appears and is a definite UX win.

## Review

@KimberlyMunoz do you mind doing the honors?
