### PR TITLE
give model form dashes a min-height and min-width

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
     cssmin: {
       target: {
         files: {
-          '<%= env.frontEndPath %>/css/regulations.min.css': ['<%= env.frontEndPath %>/css/style.min.css']
+          '<%= env.frontEndPath %>/css/regulations.min.css': ['<%= env.frontEndPath %>/css/style.css']
         }
       }
     },

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -492,6 +492,8 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqu
     span {
         display: inline-block;
         *display: inline;
+        min-width: 1em;
+        min-height: 1em;
         vertical-align: baseline;
         *vertical-align: auto;
         zoom: 1;

--- a/regulations/templates/regulations/generic_universal.html
+++ b/regulations/templates/regulations/generic_universal.html
@@ -6,7 +6,7 @@
 {% endcomment %}
 {% block app_js %}
         {% if env == 'built' %}
-        <link rel="stylesheet" href="{%static "regulations/css/style.min.css" %}"/>
+        <link rel="stylesheet" href="{%static "regulations/css/regulations.min.css" %}"/>
         {% else %}
         <link rel="stylesheet" href="{%static "regulations/css/style.css" %}"/>
         {% endif %}


### PR DESCRIPTION
This ensures that the dashes, which are inserted via CSS in a `<span>` tag are rendered when they are inside of an empty `<span>` element, such as:

![screen shot 2015-06-24 at 10 25 22 am](https://cloud.githubusercontent.com/assets/212533/8332329/5ab7f3ca-1a5b-11e5-846c-892062adeaf3.png)

## Review

@willbarton 