### PR TITLE
Remove float from main content

### DIFF
--- a/regulations/static/regulations/css/less/layout.less
+++ b/regulations/static/regulations/css/less/layout.less
@@ -34,7 +34,6 @@ Main Content
 @media only screen and ( min-width: 780px ) {
 
   .main-content {
-      float: left;
       margin-right: 32%; /* offset .secondary-content */
       overflow-x: none;
   }


### PR DESCRIPTION
There was a float applied to the main content area. This only had an ill visual effect when the content didn't feel the screen (such as [Reserved] sections).

## Before

Content ended mid-page (noticeable in the next/previous links):

![screen shot 2015-06-25 at 6 34 08 am](https://cloud.githubusercontent.com/assets/212533/8352575/42aa8a8c-1b04-11e5-8a6c-0b1674af239e.png)

## Now

Content always fills the page

![screen shot 2015-06-25 at 6 33 50 am](https://cloud.githubusercontent.com/assets/212533/8352578/49fcd4ca-1b04-11e5-8245-3494108bc631.png)

## Review
This is a one line change. @willbarton do you mind doing the honors?
