### PR TITLE
purifycss

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,21 @@ module.exports = function(grunt) {
         }
       }
     },
+
+    /**
+     * purifycss: https://github.com/purifycss/grunt-purifycss
+     *
+     * Detects which CSS selectors are being used and creates a file without the unused CSS
+     */
+    purifycss: {
+      options: {},
+      target: {
+        src: ['regulations/templates/regulations/**/*.html', '<%= env.frontEndPath %>/js/source/**/*.js'],
+        css: ['<%= env.frontEndPath %>/css/style.css'],
+        dest: '<%= env.frontEndPath %>/css/style.css'
+      }
+    },
+
     /**
      * ESLint: https://github.com/sindresorhus/grunt-eslint
      *
@@ -156,7 +171,7 @@ module.exports = function(grunt) {
       },
       css: {
         files: ['<%= env.frontEndPath %>/css/less/**/*.less'],
-        tasks: ['less:dev']
+        tasks: ['less:dev', 'purifycss']
       },
       options: {
         livereload: true
@@ -185,6 +200,6 @@ module.exports = function(grunt) {
   grunt.registerTask('test', ['eslint', 'mocha_istanbul', 'nose']);
   grunt.registerTask('test-js', ['eslint', 'mocha_istanbul']);
   grunt.registerTask('build', ['default', 'test-js']);
-  grunt.registerTask('squish', ['browserify', 'uglify', 'less', 'cssmin']);
-  grunt.registerTask('default', ['browserify', 'uglify', 'less', 'cssmin']);
+  grunt.registerTask('squish', ['browserify', 'uglify', 'less', 'purifycss', 'cssmin']);
+  grunt.registerTask('default', ['browserify', 'uglify', 'less', 'purifycss', 'cssmin']);
 };

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-eslint": "^7.0.1",
     "grunt-mocha-istanbul": "^2.3.1",
+    "grunt-purifycss": "^0.1.0",
     "grunt-shell": "~0.4.0",
     "istanbul": "^0.3.7",
     "jsdom": "^3.1.2",


### PR DESCRIPTION
This adds [purifycss](https://github.com/purifycss/purifycss), which looks for unused CSS selectors in the templates and JavaScript and removes them from the file.

```
##################################
Before purify, CSS was 155588 chars long.
After purify, CSS is 125229 chars long. (1.2 times smaller)
##################################
This function took:  713 ms
```

The savings are pretty minimal for this project, but it's something.  `¯\_(ツ)_/¯`

## Review

@KimberlyMunoz 