### PR TITLE
Add headscripts block for landing and about pages

### DIFF
--- a/regulations/templates/regulations/generic_universal.html
+++ b/regulations/templates/regulations/generic_universal.html
@@ -10,6 +10,8 @@
         {% else %}
         <link rel="stylesheet" href="{%static "regulations/css/style.css" %}"/>
         {% endif %}
+        {% block headscripts %}
+        {% endblock %}
 {% endblock %}
 
 {% comment %}
@@ -98,6 +100,7 @@
 
 </div> <!-- /.landing-content -->
 
+{% include "regulations/full_footer.html" %}
 
 {% block endscripts %}
 {% endblock %}


### PR DESCRIPTION
This adds a `headscripts` block to the generic universal landing page template. This is so we can make jQuery available to our Google Tag Manager code.

## Review

@willbarton or @KimberlyMunoz 