### PR TITLE
Add wsgi to buildout config

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -16,6 +16,7 @@ recipe = djangorecipe
 project = regulations
 settings = settings.dev
 test = regulations
+wsgi = true
 eggs = ${buildout:eggs}
        lxml
        requests


### PR DESCRIPTION
This PR simply adds wsgi to the buildout config so that it will generate `django.wsgi` and so that regulations-site can be run with mod_wsgi.