### PR TITLE
Downgrade Django to 1.6

### DIFF
--- a/regulations/generator/api_reader.py
+++ b/regulations/generator/api_reader.py
@@ -1,11 +1,11 @@
-from django.core.cache import caches
+from django.core.cache import get_cache
 from regulations.generator import api_client
 
 
 class ApiCache(object):
     """ Interface with the cache. """
     def __init__(self):
-        self.cache = caches['api_cache']
+        self.cache = get_cache('api_cache')
 
     def get(self, key):
         return self.cache.get(key)
@@ -57,7 +57,7 @@ class ApiReader(object):
             return cached
         else:
             regulation = self.client.get('regulation/%s/%s' % (label, version))
-            # Add the tree to the cache
+            #Add the tree to the cache
             if regulation:
                 self.cache_root_and_interps(regulation, version)
                 return regulation

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ class build_frontend(Command):
         pass
 
     def run(self):
-        print __file__
         call(['./frontendbuild.sh'],
              cwd=os.path.dirname(os.path.abspath(__file__)))
 
@@ -48,7 +47,7 @@ setup(
         'bdist_egg': bdist_egg,
     },
     install_requires=[
-        'django==1.8',
+        'django==1.6',
         'lxml',
         'requests'
     ],


### PR DESCRIPTION
Downgrade Django 1.6 for now until we’re (CFPB) ready to move to 1.8.