### PR TITLE
Fix duplicate FR links in versions

### DIFF
--- a/regulations/generator/versions.py
+++ b/regulations/generator/versions.py
@@ -46,8 +46,10 @@ def fetch_grouped_history(part):
     for notice in client.notices(part)['results']:
         notice = convert_to_python(notice)
         for v in (v for v in versions
-                  if v['by_date'] == notice['effective_on']):
-            v['notices'].append(notice)
+                if v['by_date'] == notice['effective_on']):
+            # Continue if a notice with the same fr_url is already in the list
+            if not any(n['fr_url'] == notice['fr_url'] for n in v['notices']):
+                v['notices'].append(notice)
 
     for version in versions:
         version['notices'] = sorted(version['notices'], reverse=True,

--- a/regulations/tests/generator_versions_tests.py
+++ b/regulations/tests/generator_versions_tests.py
@@ -22,13 +22,29 @@ class VersionsTest(TestCase):
             {'by_date': future, 'version': 'v6'},
         ]}
 
-        n1 = {'effective_on': '2001-01-01', 'publication_date': '2000-10-10'}
-        n2 = {'effective_on': '2003-03-03', 'publication_date': '2001-01-01'}
-        n3 = {'effective_on': '2003-03-03', 'publication_date': '2002-02-02'}
-        n4 = {'effective_on': future, 'publication_date': '2005-05-05'}
-        n5 = {'effective_on': future, 'publication_date': '2005-06-05'}
-        n6 = {'effective_on': future, 'publication_date': '2005-07-05'}
-        client.notices.return_value = {'results': [n1, n2, n3, n5, n4, n6]}
+        n1 = {'effective_on': '2001-01-01', 
+                'publication_date': '2000-10-10', 
+                'fr_url': 'http://n1'}
+        n2 = {'effective_on': '2003-03-03', 
+                'publication_date': '2001-01-01', 
+                'fr_url': 'http://n2'}
+        n3 = {'effective_on': '2003-03-03', 
+                'publication_date': '2002-02-02', 
+                'fr_url': 'http://n3'}
+        n4 = {'effective_on': future, 
+                'publication_date': '2005-05-05',
+                'fr_url': 'http://n4'}
+        n5 = {'effective_on': future, 
+                'publication_date': '2005-06-05',
+                'fr_url': 'http://n5'}
+        n6 = {'effective_on': future, 
+                'publication_date': '2005-07-05',
+                'fr_url': 'http://n6'}
+        n6_1 = {'effective_on': future, 
+                'publication_date': '2005-07-05',
+                'fr_url': 'http://n6'}
+        client.notices.return_value = {
+                'results': [n1, n2, n3, n5, n4, n6, n6_1]}
 
         history = fetch_grouped_history('111')
         self.assertEqual(3, len(history))
@@ -38,6 +54,7 @@ class VersionsTest(TestCase):
         self.assertEqual('current', v2['timeline'])
         self.assertEqual('past', v3['timeline'])
 
+        # n6_1 should NOT be present in this list
         self.assertEqual(convert_to_python([n6, n5, n4]), v1['notices'])
         self.assertEqual(convert_to_python([n3, n2]), v2['notices'])
         self.assertEqual(convert_to_python([n1]), v3['notices'])


### PR DESCRIPTION
It can happen occasionally that we end up duplicate “Published MM/DD/YYYY” links to the Federal Register under a version in the regulation timeline. This PR fixes that.

For the purposes of the timeline, if a notice has the same `fr_url` as a notice already in the list, it won’t be added (because if the link is the same, the *published* date is the same, which is all we display for the notice in the timeline).

So, before this change:

<img width="237" alt="old_final_rule" src="https://cloud.githubusercontent.com/assets/10562538/9935729/4696f1c6-5d26-11e5-9fdd-d59acedfa8fd.png">

After:

<img width="239" alt="new_final_rule" src="https://cloud.githubusercontent.com/assets/10562538/9935691/175f44b2-5d26-11e5-9e71-efff6782e00b.png">
