### PR TITLE
Set up view tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
         options: {
           mask:'**/*-spec.js',
           coverageFolder: '<%= env.frontEndPath %>/js/unittests/coverage',
-          excludes: ['<%= env.frontEndPath %>/js/unittests/specs/*'],
+          excludes: ['<%= env.frontEndPath %>/js/unittests/specs/**/*'],
           coverage: false
         }
       }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
       coverage: {
         src: ['<%= env.frontEndPath %>/js/unittests/specs/**/*'],
         options: {
-          mask:'*-spec.js',
+          mask:'**/*-spec.js',
           coverageFolder: '<%= env.frontEndPath %>/js/unittests/coverage',
           excludes: ['<%= env.frontEndPath %>/js/unittests/specs/*'],
           coverage: false

--- a/regulations/static/regulations/js/source/views/main/reg-view.js
+++ b/regulations/static/regulations/js/source/views/main/reg-view.js
@@ -178,6 +178,33 @@ var RegView = ChildView.extend({
         this.loadImages();
     },
 
+    openDef: function(defId, term, $link) {
+        // if its the same definition, diff term link
+        if ($('.open-definition').attr('id') === defId) {
+            this.toggleDefinition($link);
+        }
+        else {
+            // close old definition, if there is one
+            SidebarEvents.trigger('definition:close');
+            GAEvents.trigger('definition:close', {
+                type: 'defintion',
+                by: 'opening new definition'
+            });
+
+            // open new definition
+            this.setActiveTerm($link);
+            SidebarEvents.trigger('definition:open', {
+                'id': defId,
+                'term': term
+            });
+            GAEvents.trigger('definition:open', {
+                id: defId,
+                from: this.activeSection,
+                type: 'definition'
+            });
+        }
+    },
+
     // content section key term link click handler
     termLinkHandler: function(e) {
         e.preventDefault();
@@ -196,30 +223,7 @@ var RegView = ChildView.extend({
             this.clearActiveTerms();
         }
         else {
-            // if its the same definition, diff term link
-            if ($('.open-definition').attr('id') === defId) {
-                this.toggleDefinition($link);
-            }
-            else {
-                // close old definition, if there is one
-                SidebarEvents.trigger('definition:close');
-                GAEvents.trigger('definition:close', {
-                    type: 'defintion',
-                    by: 'opening new definition'
-                });
-
-                // open new definition
-                this.setActiveTerm($link);
-                SidebarEvents.trigger('definition:open', {
-                    'id': defId,
-                    'term': term
-                });
-                GAEvents.trigger('definition:open', {
-                    id: defId,
-                    from: this.activeSection,
-                    type: 'definition'
-                });
-            }
+            this.openDef(defId, term, $link);
         }
 
         return this;

--- a/regulations/static/regulations/js/source/views/main/reg-view.js
+++ b/regulations/static/regulations/js/source/views/main/reg-view.js
@@ -3,7 +3,6 @@ var $ = require('jquery');
 var _ = require('underscore');
 var Backbone = require('backbone');
 require('../../events/scroll-stop.js');
-var unveil = require('unveil');
 var DefinitionView = require('../sidebar/definition-view');
 var RegModel = require('../../models/reg-model');
 var SectionFooterView = require('./section-footer-view');
@@ -288,6 +287,8 @@ var RegView = ChildView.extend({
 
     // lazy load images as the user scrolls
     loadImages: function() {
+        // require inside of the loadImages function to accomodate testing dependencies
+        var unveil = require('unveil');
         $('.reg-image').unveil();
     }
 });

--- a/regulations/static/regulations/js/unittests/setup.js
+++ b/regulations/static/regulations/js/unittests/setup.js
@@ -1,0 +1,9 @@
+if (typeof process === 'object') {
+  // Initialize node environment
+  global.chai = require('chai');
+  global.expect = require('chai').expect;
+  require('mocha-jsdom')();
+} else {
+  window.expect = window.chai.expect
+  window.require = function () { /* noop */ }
+}

--- a/regulations/static/regulations/js/unittests/setup.js
+++ b/regulations/static/regulations/js/unittests/setup.js
@@ -4,6 +4,6 @@ if (typeof process === 'object') {
   global.expect = require('chai').expect;
   require('mocha-jsdom')();
 } else {
-  window.expect = window.chai.expect
-  window.require = function () { /* noop */ }
+  window.expect = window.chai.expect;
+  window.require = function () { /* noop */ };
 }

--- a/regulations/static/regulations/js/unittests/specs/helpers-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/helpers-spec.js
@@ -1,12 +1,9 @@
-var expect = require('chai').expect;
-var jsdom = require('mocha-jsdom');
+require('../setup');
 
 describe('Non-DOM Helper functions:', function() {
     'use strict';
 
     var $, Helpers;
-
-    jsdom();
 
     before(function (){
         $ = require('jquery');
@@ -124,8 +121,6 @@ describe('Version Finder Helper Functions:', function() {
     'use strict';
 
     var $, Helpers;
-
-    jsdom();
 
     var navMenu, navMenu_blank, section, section_blank, timeline, timeline_blank;
 

--- a/regulations/static/regulations/js/unittests/specs/models/definition-model-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/models/definition-model-spec.js
@@ -1,13 +1,9 @@
-var chai = require('chai');
-var expect = chai.expect;
-var jsdom = require('mocha-jsdom');
+require('../../setup');
 
 describe('Definition Model:', function() {
     'use strict';
 
     var $, Backbone, DefinitionModel, Resources;
-
-    jsdom();
 
     before(function (){
         Backbone = require('backbone');

--- a/regulations/static/regulations/js/unittests/specs/models/diff-model-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/models/diff-model-spec.js
@@ -1,13 +1,9 @@
-var chai = require('chai');
-var expect = chai.expect;
-var jsdom = require('mocha-jsdom');
+require('../../setup');
 
 describe('Diff Model:', function() {
     'use strict';
 
     var $, Backbone, DiffModel, Resources;
-
-    jsdom();
 
     before(function (){
         Backbone = require('backbone');

--- a/regulations/static/regulations/js/unittests/specs/models/meta-model-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/models/meta-model-spec.js
@@ -1,18 +1,13 @@
-var chai = require('chai');
-var expect = chai.expect;
+require('../../setup');
 var sinon = require('sinon'); // Run npm install for this.
 var sinonChai = require('sinon-chai');
-var jsdom = require('mocha-jsdom');
 
 chai.use(sinonChai);
-
 
 describe('MetaModel:', function() {
     'use strict';
 
     var $, Backbone, MetaModel, Resources;
-
-    jsdom();
 
     before(function (){
         Backbone = require('backbone');
@@ -84,4 +79,3 @@ describe('MetaModel:', function() {
         expect(cb).to.have.been.calledWith(false);
     });
 });
-

--- a/regulations/static/regulations/js/unittests/specs/models/search-model-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/models/search-model-spec.js
@@ -1,13 +1,9 @@
-var chai = require('chai');
-var expect = chai.expect;
-var jsdom = require('mocha-jsdom');
+require('../../setup');
 
 describe('Search Model:', function() {
     'use strict';
 
     var $, Backbone, SearchModel, Resources;
-
-    jsdom();
 
     before(function (){
         Backbone = require('backbone');

--- a/regulations/static/regulations/js/unittests/specs/models/sidebar-model-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/models/sidebar-model-spec.js
@@ -1,13 +1,9 @@
-var chai = require('chai');
-var expect = chai.expect;
-var jsdom = require('mocha-jsdom');
+require('../../setup');
 
 describe('Sidebar Model:', function() {
     'use strict';
 
     var $, Backbone, SidebarModel, Resources;
-
-    jsdom();
 
     before(function (){
         Backbone = require('backbone');

--- a/regulations/static/regulations/js/unittests/specs/models/sxs-model-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/models/sxs-model-spec.js
@@ -1,13 +1,9 @@
-var chai = require('chai');
-var expect = chai.expect;
-var jsdom = require('mocha-jsdom');
+require('../../setup');
 
 describe('SxS Model:', function() {
     'use strict';
 
     var $, Backbone, SxSModel, Resources;
-
-    jsdom();
 
     before(function (){
         Backbone = require('backbone');

--- a/regulations/static/regulations/js/unittests/specs/views/header/header-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/header/header-view-spec.js
@@ -1,0 +1,51 @@
+require('../../../setup');
+var sinon = require( 'sinon' );
+
+describe('Header View:', function () {
+
+  var view, $, e, HeaderView;
+
+  before(function () {
+    $ = require('jquery');
+    HeaderView = require('../../../../source/views/header/header-view');
+    sandbox = sinon.sandbox.create();
+  });
+
+  beforeEach(function(){
+    //  Adding a simplified version of the thing we want to test.
+    $( 'body' ).html(
+      '<header id="site-header" class="reg-header chrome-header open" role="banner">' +
+        '<div class="main-head">' +
+          '<div class="title">' +
+            '<h1 class="site-title"><a href="/"><span class="e">e</span>Regulations</a></h1>' +
+            '<h2 class="reg-title"><a href="/#">Pizza Standards</a></h2>' +
+          '</div>' +
+          '<nav class="app-nav">' +
+            '<a href="#" class="mobile-nav-trigger">' +
+             '<span class="cf-icon cf-icon-menu"></span>' +
+             '<span class="icon-text">Mobile navigation</span>' +
+            '</a>' +
+              '<ul class="app-nav-list">' +
+                '<li class="app-nav-list-item"><a href="/">Regulations</a></li>' +
+                '<li class="app-nav-list-item"><a href="/about">About</a></li>' +
+                '<li class="app-nav-list-item org-title">' +
+                  '<a href="http://pizz.gov">pizza.gov</a>' +
+                '</li>' +
+              '</ul>' +
+          '</nav>' +
+        '</div>' +
+      '</header>'
+    );
+
+    // create a new instance of the view
+    view = new HeaderView();
+
+    view.el = $('.reg-header');
+
+  });
+
+  it('should construct a view', function() {
+    expect(view).to.be.defined;
+  });
+
+});

--- a/regulations/static/regulations/js/unittests/specs/views/header/sub-head-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/header/sub-head-view-spec.js
@@ -1,0 +1,77 @@
+require('../../../setup');
+var sinon = require( 'sinon' );
+
+describe('Sub Head View:', function () {
+
+  var view, $, e, SubHeadView;
+
+  before(function () {
+    $ = require('jquery');
+    SubHeadView = require('../../../../source/views/header/sub-head-view');
+    sandbox = sinon.sandbox.create();
+  });
+
+  beforeEach(function(){
+    //  Adding a simplified version of the thing we want to test.
+    $( 'body' ).html(
+      '<div id="content-header" class="header-main group open">' +
+        '<div class="wayfinding">' +
+          '<span class="subpart"></span>' +
+          '<span id="active-title"><em class="header-label"></em></span>' +
+        '</div>' +
+        '<span class="effective-date">' +
+        '<h2></h2>' +
+      '</div>' +
+      '<section id="1999-1" class="reg-section" data-base-version="2013-22752_20140118" data-page-type="reg-section"> </section>' +
+      '<div class="select-content">' +
+        '<form>' +
+          '<select name="new_version" onChange="this.form.submit();">' +
+            '<option value="default" disabled="disabled" selected="selected">regulation effective</option>' +
+            '<option value="2013-22752_20140110">1/10/2014</option>' +
+          '</select>' +
+        '</form>' +
+      '</div>'
+    );
+
+    // create a new instance of the view
+    view = new SubHeadView();
+
+    view.el = $('#content-header');
+    view.$activeTitle = $('.header-label');
+  });
+
+  it('should construct a view', function() {
+    expect(view).to.be.defined;
+  });
+
+  it('populates subhead with new title', function() {
+    view.changeTitle('1999-1');
+    expect(view.$activeTitle.html()).to.contain('§1999.1');
+  });
+
+  it('displays a search result count', function() {
+    view.displayCount('42');
+    expect(view.$activeTitle.text()).to.contain('Search results 42');
+  });
+
+  it('changes the effective data', function() {
+    view.changeDate();
+    expect($('.effective-date').text()).to.have.string('Effective date: ');
+  });
+
+  it('should render the subpart', function() {
+    view.renderSubpart('pepperoni');
+    var $classes = view.$activeTitle.attr('class');
+    expect($('.subpart').text()).to.have.string('pepperoni');
+    expect($classes).to.eql('header-label with-subpart');
+  });
+
+  it('should remove the subpart', function() {
+    view.renderSubpart('mushroom');
+    view.removeSubpart();
+    var $classes = view.$activeTitle.attr('class');
+    expect($('.subpart').text()).to.not.have.string('mushroom');
+    expect($classes).to.eql('header-label');
+  });
+
+});

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/definition-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/definition-view-spec.js
@@ -1,25 +1,35 @@
-var chai = require('chai');
-var expect = chai.expect;
-var jsdom = require('mocha-jsdom');
+require('../../../setup');
 
-describe('Definition View:', function() {
-    'use strict';
+describe('Definition View:', function () {
 
-    var view, $, Backbone, _, DefinitionView, SidebarModuleView, RegModel, Helpers, Router, MainEvents, SidebarEvents, GAEvents;
+  var view, $, DefinitionView;
 
-    jsdom();
+  before(function () {
+    $ = require('jquery');
+    DefinitionView = require('../../../../source/views/sidebar/definition-view');
+  });
 
-    before(function (){
-        $ = require('jquery');
-        Backbone = require('backbone');
-        DefinitionView = require('../../../../source/views/sidebar/definition-view');
-    });
+  beforeEach(function(){
+      view = new DefinitionView({
+        id: '1',
+        term: 'Peanut Butter Jelly'
+      });
 
-    beforeEach(function(){
-        view = new DefinitionView();
-    });
+      view.render();
+  });
 
-    it('should construct a veiw', function() {
-        expect(view).to.be.ok;
-    });
+  it('works', function () {
+    document.body.innerHTML = '<div>hola</div>';
+    expect($("div").html()).eql('hola');
+  });
+
+  it('has document', function () {
+    var div = document.createElement('div');
+    expect(div.nodeName).eql('DIV');
+  });
+
+  it('should construct a veiw', function() {
+      expect(view).to.be.ok;
+  });
+
 });

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/definition-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/definition-view-spec.js
@@ -1,0 +1,25 @@
+var chai = require('chai');
+var expect = chai.expect;
+var jsdom = require('mocha-jsdom');
+
+describe('Definition View:', function() {
+    'use strict';
+
+    var view, $, Backbone, _, DefinitionView, SidebarModuleView, RegModel, Helpers, Router, MainEvents, SidebarEvents, GAEvents;
+
+    jsdom();
+
+    before(function (){
+        $ = require('jquery');
+        Backbone = require('backbone');
+        DefinitionView = require('../../../../source/views/sidebar/definition-view');
+    });
+
+    beforeEach(function(){
+        view = new DefinitionView();
+    });
+
+    it('should construct a veiw', function() {
+        expect(view).to.be.ok;
+    });
+});

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/definition-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/definition-view-spec.js
@@ -49,18 +49,56 @@ describe('Definition View:', function () {
 
   describe('Render methods:', function () {
 
-    it('renders the header with loading indicator', function () {
+    it('should render the header with loading indicator', function () {
       view.renderHeader();
       expect(view.$el.html()).to.eql(
         '<div class="sidebar-header group spinner"><h4>Defined Term</h4></div>'
       );
     });
 
-    it('renders definition HTML', function() {
+    it('should render definition HTML', function() {
       view.render(content);
       expect(view.$el.html()).to.contain('90s narwhal vegan artisan');
     });
 
+    it('should display an error when renderError is called', function() {
+      var err = new Error('Oh snap!');
+      view.renderError(err);
+      expect(view.$el.html()).to.contain('Oh snap!');
+    });
+
   });
+
+  describe('Definitions with content:', function () {
+
+    beforeEach(function(){
+      view.render(content);
+    });
+
+    it('should be closeable', function() {
+      $('.close-button').trigger('click');
+      expect(view.$el.html()).to.not.contain('90s narwhal vegan artisan');
+    });
+
+    it('should display a scope warning when called', function() {
+      view.displayScopeMsg('1005-2-a-1');
+      expect(view.$el.html()).to.contain(
+        'This term has a different definition for some portions of'
+      );
+
+      it('should be able to remove the scope warning', function() {
+        view.displayScopeMsg('1005-2-a-1');
+        view.removeScopeMsg();
+        expect(view.$el.html()).to.not.contain(
+          'This term has a different definition for some portions of'
+        );
+      });
+    });
+
+  });
+
+
+
+
 
 });

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/definition-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/definition-view-spec.js
@@ -1,35 +1,66 @@
 require('../../../setup');
+var sinon = require( 'sinon' );
 
 describe('Definition View:', function () {
 
-  var view, $, DefinitionView;
+  var view, definition, content, $, DefinitionView;
 
   before(function () {
     $ = require('jquery');
     DefinitionView = require('../../../../source/views/sidebar/definition-view');
+    sandbox = sinon.sandbox.create();
   });
 
   beforeEach(function(){
-      view = new DefinitionView({
-        id: '1',
-        term: 'Peanut Butter Jelly'
-      });
 
-      view.render();
+    //  Adding a simplified version of the thing we want to test.
+    $( 'body' ).html(
+      '<section id="definition"></section>'
+    );
+
+    // some HTML to insert into the definition
+    content = '<div id="1005-2-a-1" class="open-definition">'+
+        '<div class="sidebar-header group">' +
+            '<h4>Defined Term <a class="right close-button" href="#">Close definition</a></h4>' +
+        '</div>' +
+        '<div class="definition-warning hidden group">' +
+            '<span class="cf-icon cf-icon-error icon-warning"></span>' +
+            '<div class="msg">' +
+            '</div>' +
+        '</div>' +
+        '<div class="definition-text">' +
+            '<p>Sustainable quinoa lo-fi, cray leggings plaid Intelligentsia hoodie ' +
+            'forage tofu. 90s narwhal vegan artisan, Shoreditch cornhole sustainable ' +
+            'distillery Brooklyn. </p>' +
+            '<a href="/1005-2/2014-20681#1005-2-a-1" class="continue-link full-def internal"' + 'data-linked-section="1005-2-a-1">§ 1005.2(a)(1)</a>' +
+            '<a class="close-button tab-activated" href="#">Close definition</a>' +
+        '</div>' +
+    '</div>';
+
+    // create a new instance of the view
+    view = new DefinitionView();
+
+    view.el = $('#definition');
   });
 
-  it('works', function () {
-    document.body.innerHTML = '<div>hola</div>';
-    expect($("div").html()).eql('hola');
+  it('should construct a view', function() {
+    expect(view).to.be.defined;
   });
 
-  it('has document', function () {
-    var div = document.createElement('div');
-    expect(div.nodeName).eql('DIV');
-  });
+  describe('Render methods:', function () {
 
-  it('should construct a veiw', function() {
-      expect(view).to.be.ok;
+    it('renders the header with loading indicator', function () {
+      view.renderHeader();
+      expect(view.$el.html()).to.eql(
+        '<div class="sidebar-header group spinner"><h4>Defined Term</h4></div>'
+      );
+    });
+
+    it('renders definition HTML', function() {
+      view.render(content);
+      expect(view.$el.html()).to.contain('90s narwhal vegan artisan');
+    });
+
   });
 
 });

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/help-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/help-view-spec.js
@@ -1,0 +1,23 @@
+require('../../../setup');
+var sinon = require( 'sinon' );
+
+describe('Help View:', function () {
+
+  var view, definition, $, HelpView;
+
+  before(function () {
+    $ = require('jquery');
+    HelpView = require('../../../../source/views/sidebar/help-view');
+    sandbox = sinon.sandbox.create();
+  });
+
+  beforeEach(function(){
+    // create a new instance of the view
+    view = new HelpView();
+  });
+
+  it('should construct a view', function() {
+    expect(view).to.be.defined;
+  });
+
+});

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-list-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-list-view-spec.js
@@ -1,0 +1,23 @@
+require('../../../setup');
+var sinon = require( 'sinon' );
+
+describe('Sidebar List View:', function () {
+
+  var view, definition, $, SidebarList;
+
+  before(function () {
+    $ = require('jquery');
+    SidebarList = require('../../../../source/views/sidebar/sidebar-list-view');
+    sandbox = sinon.sandbox.create();
+  });
+
+  beforeEach(function(){
+    // create a new instance of the view
+    view = new SidebarList();
+  });
+
+  it('should construct a view', function() {
+    expect(view).to.be.defined;
+  });
+
+});

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-module-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-module-view-spec.js
@@ -1,0 +1,42 @@
+require('../../../setup');
+var sinon = require( 'sinon' );
+
+describe('Sidebar Module View:', function () {
+
+  var view, definition, $, SidebarList;
+
+  before(function () {
+    $ = require('jquery');
+    SidebarModule = require('../../../../source/views/sidebar/sidebar-module-view');
+    RegModel = require('../../../../source/models/reg-model');
+    sandbox = sinon.sandbox.create();
+  });
+
+  beforeEach(function(){
+
+    // create a fake RegModel
+    RegModel.get = function(){
+      return 'supreme pizza';
+    };
+
+    //  Adding a simplified version of the thing we want to test.
+    $( 'body' ).html(
+      '<section id="sidebar-module"></section>'
+    );
+
+    // create a new instance of the view
+    view = new SidebarModule();
+    view.$el = $('#sidebar-module');
+
+  });
+
+  it('should construct a view', function() {
+    expect(view).to.be.defined;
+  });
+
+  it('should render content in the view', function() {
+    view.render();
+    expect(view.$el.text()).to.contain('supreme pizza');
+  });
+
+});

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-view-spec.js
@@ -1,0 +1,24 @@
+require('../../../setup');
+var sinon = require( 'sinon' );
+
+describe('SxS List View:', function () {
+
+  var view, definition, $, SidebarView;
+
+  before(function () {
+    $ = require('jquery');
+    SidebarView = require('../../../../source/views/sidebar/sidebar-view');
+    sandbox = sinon.sandbox.create();
+  });
+
+  beforeEach(function(){
+    // create a new instance of the view
+    view = new SidebarView();
+
+  });
+
+  it('should construct a view', function() {
+    expect(view).to.be.defined;
+  });
+
+});

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-view-spec.js
@@ -1,7 +1,7 @@
 require('../../../setup');
 var sinon = require( 'sinon' );
 
-describe('SxS List View:', function () {
+describe('Sidebar View:', function () {
 
   var view, definition, $, SidebarView;
 
@@ -18,7 +18,7 @@ describe('SxS List View:', function () {
     );
 
     function sidebarModelMock () {
-      
+
     }
 
 

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/sidebar-view-spec.js
@@ -12,6 +12,16 @@ describe('SxS List View:', function () {
   });
 
   beforeEach(function(){
+
+    $( 'body' ).html(
+      '<div id="sidebar-content"></div>'
+    );
+
+    function sidebarModelMock () {
+      
+    }
+
+
     // create a new instance of the view
     view = new SidebarView();
 

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/sxs-list-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/sxs-list-view-spec.js
@@ -1,0 +1,24 @@
+require('../../../setup');
+var sinon = require( 'sinon' );
+
+describe('SxS List View:', function () {
+
+  var view, definition, $, SxSList;
+
+  before(function () {
+    $ = require('jquery');
+    SxSList = require('../../../../source/views/sidebar/sxs-list-view');
+    sandbox = sinon.sandbox.create();
+  });
+
+  beforeEach(function(){
+    // create a new instance of the view
+    view = new SxSList();
+
+  });
+
+  it('should construct a view', function() {
+    expect(view).to.be.defined;
+  });
+
+});


### PR DESCRIPTION
Up until now we haven't been testing JS views, because it is a tricky thing to do. Unfortunately, a lot of the current application logic lives in those views. This sets up some basic view testing specifically for the sidebar views for now.

I'm hoping to work with @imuchnik when she returns from vacation to figure out how to mock the Ajax requests, which many of the views rely on.

This can remain unmerged until it is in a more complete state, but I wanted to open up a PR to more easily get more eyes on it.

