### PR TITLE
Always hit GTM over HTTPS

### DIFF
--- a/regulations/templates/regulations/base.html
+++ b/regulations/templates/regulations/base.html
@@ -55,12 +55,12 @@ CSS/Javascript etc., should inherit from this template.
     <!--[if gt IE 9]><!--><body><!--<![endif]-->
 
     <!-- Google Tag Manager -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
     <!-- End Google Tag Manager -->
 


### PR DESCRIPTION
Tiny change, just adds `https:` before the `//` protocol-relative URLs.