### PR TITLE
improve subeader content at responsive points

### DIFF
--- a/regulations/static/regulations/css/less/layout.less
+++ b/regulations/static/regulations/css/less/layout.less
@@ -187,7 +187,6 @@ TOC Header Navigation
 }
 
 .header-main { /* TODO: closely matches main content layout - should unify into single class*/
-    margin-right: 25%;
     margin-left: 240px;
     padding-left: 65px;
 }
@@ -212,7 +211,6 @@ TOC Header Navigation
 
     .header-main {
         margin-left: 40px;
-        margin-right: 32%;
     }
 
     .content-header {

--- a/regulations/static/regulations/css/less/module/header.less
+++ b/regulations/static/regulations/css/less/module/header.less
@@ -386,17 +386,13 @@ Small Screens
 
 @media only screen and ( max-width: 600px ) {
 
-    .header-label {
-        margin-left: 6px;
+    .header-label,
+    .effective-date {
+        margin-left: 10px;
     }
 }
 
 @media only screen and ( max-width: 780px ) {
-
-    .header-label {
-        margin-left: 10px;
-    }
-
     #content-header {
         padding-left: 20px;
     }


### PR DESCRIPTION
We had an issue where in Reg D and search results the subheader appeared broken at various breakpoints, like so:

![screen shot 2015-11-30 at 9 48 33 am](https://cloud.githubusercontent.com/assets/212533/11474713/b8ece8ec-9747-11e5-8226-2e2c11268c8b.png)
![screen shot 2015-11-30 at 9 49 09 am](https://cloud.githubusercontent.com/assets/212533/11474715/bbef6b64-9747-11e5-9e2e-1d38a298039f.png)

This should fix that issue:

![screen shot 2015-11-30 at 9 48 53 am](https://cloud.githubusercontent.com/assets/212533/11474732/d62144c6-9747-11e5-99fd-d2a0a7e3f161.png)

![screen shot 2015-11-30 at 9 49 24 am](https://cloud.githubusercontent.com/assets/212533/11474738/dac6ae8a-9747-11e5-9fc9-409a4893034e.png)


## Review

@willbarton 