### PR TITLE
Appendix headings style fixes

### DIFF
--- a/regulations/static/regulations/css/less/module/interpretations.less
+++ b/regulations/static/regulations/css/less/module/interpretations.less
@@ -16,17 +16,19 @@
         cursor: auto;
     }
 
-    h4 {
-        color: @black;
-        text-transform: uppercase;
-        .avenir-next;
-        display: inline-block;
-        font-size: .8em;
-        margin: 0;
-        padding: 0 0 0 20px;
-        background: url(../img/interpretation.png) no-repeat 0 3px;
+    .inline-interp-header {
+      h4 {
+          color: @black;
+          text-transform: uppercase;
+          .avenir-next;
+          display: inline-block;
+          font-size: .8em;
+          margin: 0;
+          padding: 0 0 0 20px;
+          background: url(../img/interpretation.png) no-repeat 0 3px;
+      }
     }
-
+    
     .expand-button {
         color: @pacific;
         .avenir-next-demi;

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -409,15 +409,15 @@ The `<ol>` tag needs to have the appropriate list type applied
   display: none;
 }
 
-.appendix-section .stripped-marker {
-  display: block;
-  float: left;
-  margin-left: -20px;
-  width: 20px;
+.appendix-section {
+  .stripped-marker {
+    display: inline-block;
+    margin-left: -16px;
+    margin-right: 4px;
+  }
 }
-
 .appendix-section .inline-interpretation-content .stripped-marker {
-    margin-left: -24px;
+    margin-left: -20px;
     width: 24px;
 }
 
@@ -440,12 +440,19 @@ within the context of the regulation.
 
 See [MDN's `<dfn>` tag reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn) for more info.
 
-All key-terms are displayed as block elements to force a line-break.
+All key-terms are displayed as block elements to force a line-break,
+except in the appendix where we use inline-block to accomodate the marker styles
 
 */
 
 .key-term {
     display: block;
+}
+
+.appendix-section {
+  .key-term {
+    display: inline-block;
+  }
 }
 
 /*  Level-1 Key-Terms


### PR DESCRIPTION
This addresses two tiny bits of weirdness found in the styles.

(1) `<h4>`s in the slide down interp content were rendered with a little icon.

Before:
![screen shot 2015-12-09 at 12 08 53 pm](https://cloud.githubusercontent.com/assets/212533/11692538/fe551f44-9e6d-11e5-9c25-f6d87dc7ba47.png)

Now:
![screen shot 2015-12-09 at 12 09 22 pm](https://cloud.githubusercontent.com/assets/212533/11692545/044d197e-9e6e-11e5-8a45-eb1994342b85.png)

(2) Markers in the Appendices had a funky line height when next to a key-term.

Before:
![screen shot 2015-12-09 at 12 07 50 pm](https://cloud.githubusercontent.com/assets/212533/11692568/1ca1a9fe-9e6e-11e5-90ec-144801d7bfd5.png)


Now:
![screen shot 2015-12-09 at 12 07 40 pm](https://cloud.githubusercontent.com/assets/212533/11692564/1741c4ee-9e6e-11e5-81d4-2977e1cde8e8.png)

## Review

@grapesmoker or @willbarton 
