### PR TITLE
Begin to modularize layer data by adding a setting

### DIFF
--- a/regulations/generator/generator.py
+++ b/regulations/generator/generator.py
@@ -1,3 +1,4 @@
+from importlib import import_module
 import logging
 import re
 from threading import Thread
@@ -5,59 +6,34 @@ from threading import Thread
 from django.conf import settings
 
 import api_reader
-from layers.defined import DefinedLayer
-from layers.definitions import DefinitionsLayer
-from layers.external_citation import ExternalCitationLayer
-from layers.formatting import FormattingLayer
-from layers.internal_citation import InternalCitationLayer
-from layers.interpretations import InterpretationsLayer
-from layers.key_terms import KeyTermsLayer
-from layers.meta import MetaLayer
-from layers.layers_applier import InlineLayersApplier
-from layers.layers_applier import ParagraphLayersApplier
-from layers.layers_applier import SearchReplaceLayersApplier
-from layers.paragraph_markers import ParagraphMarkersLayer
-from layers.toc_applier import TableOfContentsLayer
-from layers.graphics import GraphicsLayer
+from regulations.generator.layers.base import LayerBase
+from regulations.generator.layers.layers_applier import (
+    InlineLayersApplier, ParagraphLayersApplier, SearchReplaceLayersApplier)
 from layers.diff_applier import DiffApplier
 from html_builder import HTMLBuilder
 import notices
 
 
+def _data_layers():
+    """Index all configured data layers by their "shorthand". This doesn't
+    have any error checking -- it'll explode if configured improperly"""
+    layers = {}
+    for class_path in settings.DATA_LAYERS:
+        module, class_name = class_path.rsplit('.', 1)
+        klass = getattr(import_module(module), class_name)
+        layers[klass.shorthand] = klass
+    return layers
+
+
 class LayerCreator(object):
     """ This lets us dynamically load layers by shorthand. """
-    DEFINED = DefinedLayer.shorthand
-    EXTERNAL = ExternalCitationLayer.shorthand
-    GRAPHICS = GraphicsLayer.shorthand
-    INTERNAL = InternalCitationLayer.shorthand
-    INTERP = InterpretationsLayer.shorthand
-    KEY_TERMS = KeyTermsLayer.shorthand
-    META = MetaLayer.shorthand
-    PARAGRAPH = ParagraphMarkersLayer.shorthand
-    FORMATTING = FormattingLayer.shorthand
-    TERMS = DefinitionsLayer.shorthand
-    TOC = TableOfContentsLayer.shorthand
-
-    LAYERS = {
-        DEFINED: ('terms', 'inline', DefinedLayer),
-        #EXTERNAL: ('external-citations', 'inline', ExternalCitationLayer),
-        GRAPHICS: ('graphics', 'search_replace', GraphicsLayer),
-        INTERNAL: ('internal-citations', 'inline', InternalCitationLayer),
-        INTERP: ('interpretations', 'paragraph', InterpretationsLayer),
-        KEY_TERMS: ('keyterms', 'search_replace', KeyTermsLayer),
-        META: ('meta', 'paragraph', MetaLayer),
-        PARAGRAPH: (
-            'paragraph-markers', 'search_replace', ParagraphMarkersLayer),
-        FORMATTING: ('formatting', 'search_replace', FormattingLayer),
-        TERMS: ('terms', 'inline', DefinitionsLayer),
-        TOC: ('toc', 'paragraph', TableOfContentsLayer),
-    }
+    LAYERS = _data_layers()
 
     def __init__(self):
         self.appliers = {
-            'inline': InlineLayersApplier(),
-            'paragraph': ParagraphLayersApplier(),
-            'search_replace': SearchReplaceLayersApplier()}
+            LayerBase.INLINE: InlineLayersApplier(),
+            LayerBase.PARAGRAPH: ParagraphLayersApplier(),
+            LayerBase.SEARCH_REPLACE: SearchReplaceLayersApplier()}
 
         self.api = api_reader.ApiReader()
 
@@ -70,8 +46,9 @@ class LayerCreator(object):
         """
 
         if layer_name.lower() in LayerCreator.LAYERS:
-            api_name, applier_type,\
-                layer_class = LayerCreator.LAYERS[layer_name]
+            layer_class = LayerCreator.LAYERS[layer_name]
+            api_name = layer_class.data_source
+            applier_type = layer_class.layer_type
             layer_json = self.get_layer_json(api_name, regulation, version)
             if layer_json is None:
                 logging.warning("No data for %s/%s/%s"
@@ -90,48 +67,49 @@ class LayerCreator(object):
         """Request a list of layers. As this might spawn multiple HTTP
         requests, we wrap the requests in threads so they can proceed
         concurrently."""
-        #This doesn't deal with sectional interpretations yet.
-        #we'll have to do that.
-        layer_names = set(filter(lambda l: l.lower() in LayerCreator.LAYERS,
-                                 layer_names))
+        # This doesn't deal with sectional interpretations yet.
+        # we'll have to do that.
+        layer_names = set(l for l in layer_names
+                          if l.lower() in LayerCreator.LAYERS)
         results = []
         procs = []
- 
+
         def one_layer(layer_name):
-            api_name, applier_type,\
-                layer_class = LayerCreator.LAYERS[layer_name]
+            layer_class = LayerCreator.LAYERS[layer_name]
+            api_name = layer_class.data_source
+            applier_type = layer_class.layer_type
             layer_json = self.get_layer_json(api_name, regulation, version)
             results.append((api_name, applier_type, layer_class, layer_json))
- 
+
         #   Spawn threads
         for layer_name in layer_names:
             proc = Thread(target=one_layer, args=(layer_name,))
             procs.append(proc)
             proc.start()
- 
+
         #   Join them (once their work is done)
         for proc in procs:
             proc.join()
-            
+
         for api_name, applier_type, layer_class, layer_json in results:
             if layer_json is None:
                 logging.warning("No data for %s/%s/%s"
                                 % (api_name, regulation, version))
             else:
                 layer = layer_class(layer_json)
- 
+
                 if sectional and hasattr(layer, 'sectional'):
                     layer.sectional = sectional
                 if hasattr(layer, 'version'):
                     layer.version = version
- 
+
                 self.appliers[applier_type].add_layer(layer)
 
     def get_appliers(self):
         """ Return the appliers. """
-        return (self.appliers['inline'],
-                self.appliers['paragraph'],
-                self.appliers['search_replace'])
+        return (self.appliers[LayerBase.INLINE],
+                self.appliers[LayerBase.PARAGRAPH],
+                self.appliers[LayerBase.SEARCH_REPLACE])
 
 
 class DiffLayerCreator(LayerCreator):

--- a/regulations/generator/layers/analyses.py
+++ b/regulations/generator/layers/analyses.py
@@ -1,7 +1,7 @@
 from itertools import takewhile
 
-from regulations.generator.node_types import label_to_text
 from regulations.generator.layers.tree_builder import make_label_sortable
+from regulations.generator.node_types import label_to_text
 
 
 def sort_regtext_label(label):
@@ -39,9 +39,8 @@ def sort_analyses(analyses):
         return sorted_analyses
 
 
+# This is unlike other layers in that it is only used in the right sidebar
 class SectionBySectionLayer(object):
-    shorthand = 'sxs'
-
     def __init__(self, layer):
         self.layer = layer
         # Perform the computations we'll use when applying the layer only once

--- a/regulations/generator/layers/base.py
+++ b/regulations/generator/layers/base.py
@@ -1,0 +1,32 @@
+import abc
+
+
+class LayerBase(object):
+    """Base class for most layers; each layer contains information which is
+    added on top of the regulation, such as definitions, internal citations,
+    keyterms, etc."""
+    __metaclass__ = abc.ABCMeta
+
+    # @see layer_type
+    INLINE = 'inline'
+    PARAGRAPH = 'paragraph'
+    SEARCH_REPLACE = 'search_replace'
+
+    @abc.abstractproperty
+    def shorthand(self):
+        """A short description for this layer. This is used in query strings
+        and the like to define which layers should be used"""
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def data_source(self):
+        """Data is pulled from the API; this field indicates the name of the
+        endpoint to pull data from"""
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def layer_type(self):
+        """Layer data can be applied in a few ways, attaching itself to a
+        node, replacing text based on offset, or replacing text based on
+        searching. Which type is this layer?"""
+        raise NotImplementedError

--- a/regulations/generator/layers/defined.py
+++ b/regulations/generator/layers/defined.py
@@ -1,8 +1,12 @@
 from django.template import loader, Context
 
+from regulations.generator.layers.base import LayerBase
 
-class DefinedLayer(object):
+
+class DefinedLayer(LayerBase):
     shorthand = 'defined'
+    data_source = 'terms'
+    layer_type = LayerBase.INLINE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/definitions.py
+++ b/regulations/generator/layers/definitions.py
@@ -1,12 +1,15 @@
 from django.template import loader, Context
 
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.section_url import SectionUrl
 from ..node_types import to_markup_id
 import utils
 
 
-class DefinitionsLayer(object):
+class DefinitionsLayer(LayerBase):
     shorthand = 'terms'
+    data_source = 'terms'
+    layer_type = LayerBase.INLINE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/external_citation.py
+++ b/regulations/generator/layers/external_citation.py
@@ -2,9 +2,13 @@ import urllib
 from django.template import loader
 import utils
 
+from regulations.generator.layers.base import LayerBase
 
-class ExternalCitationLayer():
+
+class ExternalCitationLayer(LayerBase):
     shorthand = 'external'
+    data_source = 'terms'
+    layer_type = LayerBase.INLINE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/formatting.py
+++ b/regulations/generator/layers/formatting.py
@@ -3,9 +3,13 @@ import re
 
 from django.template import loader, Context
 
+from regulations.generator.layers.base import LayerBase
 
-class FormattingLayer(object):
+
+class FormattingLayer(LayerBase):
     shorthand = 'formatting'
+    data_source = 'formatting'
+    layer_type = LayerBase.SEARCH_REPLACE
 
     def __init__(self, layer_data):
         self.layer_data = layer_data

--- a/regulations/generator/layers/graphics.py
+++ b/regulations/generator/layers/graphics.py
@@ -1,9 +1,13 @@
 from django.template import loader
 import utils
 
+from regulations.generator.layers.base import LayerBase
 
-class GraphicsLayer(object):
+
+class GraphicsLayer(LayerBase):
     shorthand = 'graphics'
+    data_source = 'graphics'
+    layer_type = LayerBase.SEARCH_REPLACE
 
     def __init__(self, layer_data):
         self.layer_data = layer_data

--- a/regulations/generator/layers/internal_citation.py
+++ b/regulations/generator/layers/internal_citation.py
@@ -2,11 +2,14 @@ from django.template import loader, Context
 from django.core.urlresolvers import reverse, NoReverseMatch
 from ..node_types import to_markup_id
 
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.section_url import SectionUrl
 
 
-class InternalCitationLayer():
+class InternalCitationLayer(LayerBase):
     shorthand = 'internal'
+    data_source = 'internal-citations'
+    layer_type = LayerBase.INLINE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/interpretations.py
+++ b/regulations/generator/layers/interpretations.py
@@ -2,13 +2,16 @@ from django.http import HttpRequest
 
 #   Don't import PartialInterpView or utils directly; causes an import cycle
 from regulations import generator, views
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.node_types import label_to_text
 from regulations.generator.section_url import SectionUrl
 
 
-class InterpretationsLayer(object):
+class InterpretationsLayer(LayerBase):
     """Fetches the (rendered) interpretation for this node, if available"""
     shorthand = 'interp'
+    data_source = 'interpretations'
+    layer_type = LayerBase.PARAGRAPH
 
     def __init__(self, layer, version=None):
         self.layer = layer

--- a/regulations/generator/layers/key_terms.py
+++ b/regulations/generator/layers/key_terms.py
@@ -1,9 +1,14 @@
 import string
 import utils
-from django.template import loader, Context
+from django.template import loader
 
-class KeyTermsLayer(object):
+from regulations.generator.layers.base import LayerBase
+
+
+class KeyTermsLayer(LayerBase):
     shorthand = 'keyterms'
+    data_source = 'keyterms'
+    layer_type = LayerBase.SEARCH_REPLACE
 
     def __init__(self, layer):
         self.layer = layer
@@ -14,9 +19,9 @@ class KeyTermsLayer(object):
         return punctuated.translate(translate_table)
 
     def generate_tag(self, key_term):
-        key_term = {'key_term':key_term,
-            'phrase':self.remove_punctuation(key_term)}
-        context = {'key_term':key_term}
+        key_term = {'key_term': key_term,
+                    'phrase': self.remove_punctuation(key_term)}
+        context = {'key_term': key_term}
         return utils.render_template(self.template, context)
 
     def apply_layer(self, text_index):
@@ -25,7 +30,7 @@ class KeyTermsLayer(object):
             layer_elements = self.layer[text_index]
 
             for layer_element in layer_elements:
-                key_term = layer_element['key_term'] 
+                key_term = layer_element['key_term']
                 key_term_tag = self.generate_tag(key_term)
                 locations = layer_element['locations']
                 elements.append((key_term, key_term_tag, locations))

--- a/regulations/generator/layers/meta.py
+++ b/regulations/generator/layers/meta.py
@@ -1,7 +1,11 @@
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.layers.utils import convert_to_python
 
-class MetaLayer(object):
+
+class MetaLayer(LayerBase):
     shorthand = 'meta'
+    data_source = 'meta'
+    layer_type = LayerBase.PARAGRAPH
 
     def __init__(self, layer_data):
         self.layer_data = convert_to_python(layer_data)

--- a/regulations/generator/layers/paragraph_markers.py
+++ b/regulations/generator/layers/paragraph_markers.py
@@ -1,8 +1,13 @@
 from django.template import loader
 import utils
 
-class ParagraphMarkersLayer(object):
+from regulations.generator.layers.base import LayerBase
+
+
+class ParagraphMarkersLayer(LayerBase):
     shorthand = 'paragraph'
+    data_source = 'paragraph-markers'
+    layer_type = LayerBase.SEARCH_REPLACE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/toc_applier.py
+++ b/regulations/generator/layers/toc_applier.py
@@ -1,12 +1,15 @@
 #vim: set fileencoding=utf-8
 from regulations.generator import title_parsing
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.section_url import SectionUrl
 from regulations.generator.toc import (
     toc_interp, toc_sect_appendix, toc_subpart)
 
 
-class TableOfContentsLayer(object):
+class TableOfContentsLayer(LayerBase):
     shorthand = 'toc'
+    data_source = 'toc'
+    layer_type = LayerBase.PARAGRAPH
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -194,3 +194,21 @@ LOGGING = {
         },
     }
 }
+
+
+# Where should we look for data?
+DATA_LAYERS = (
+    'regulations.generator.layers.defined.DefinedLayer',
+    'regulations.generator.layers.definitions.DefinitionsLayer',
+    # Commented out of the defaults until the feature is considered complete
+    # 'regulations.generator.layers.external_citation.ExternalCitationLayer',
+    'regulations.generator.layers.formatting.FormattingLayer',
+    'regulations.generator.layers.internal_citation.InternalCitationLayer',
+    # Should likely be moved to a CFPB-specific module
+    'regulations.generator.layers.interpretations.InterpretationsLayer',
+    'regulations.generator.layers.key_terms.KeyTermsLayer',
+    'regulations.generator.layers.meta.MetaLayer',
+    'regulations.generator.layers.paragraph_markers.ParagraphMarkersLayer',
+    'regulations.generator.layers.toc_applier.TableOfContentsLayer',
+    'regulations.generator.layers.graphics.GraphicsLayer',
+)

--- a/regulations/tests/generator_tests.py
+++ b/regulations/tests/generator_tests.py
@@ -78,12 +78,6 @@ class GeneratorTest(TestCase):
             ('204', 'old', 'new'),
             get_diff_json.call_args[0])
 
-    def test_layercreator_layers(self):
-        """ A LAYER entry must have three pieces of information specified. """
-
-        for l, v in generator.LayerCreator.LAYERS.items():
-            self.assertEqual(len(v), 3)
-
     def test_layercreator_getappliers(self):
         creator = generator.LayerCreator()
         appliers = creator.get_appliers()


### PR DESCRIPTION
Previously, the mega `generator` module knew about most of the different types
of layers. It created a big dictionary of them for iterating through. This
patch moves that listing into a settings file so that it can be replaced by
different clients. Further, it moves data related to where the layer
information comes from and how it should be applied into the individual layer
classes; it also introduces a few constants and creates a common abstract base
class for most layers.

This does _not_ make the section-by-section analyses on the right hand side
configurable; they are currently hard coded into the sidebar view.

A.K.A. 18f/regulations-site#56. We'll have a similar group of settings for the sidebar, too. I don't remember how consumerfinance.gov's settings are configured; the default setting here may not be enough.