### PR TITLE
template logic to display markers if they're present

### DIFF
--- a/regulations/templates/regulations/tree-with-wrapper.html
+++ b/regulations/templates/regulations/tree-with-wrapper.html
@@ -3,7 +3,7 @@
 {% endcomment %}
 
 <li
-    {% if node.marker == "none"%}
+    {% if node.marker == "none" or node.marker == "" %}
         class="markerless"
     {% endif %}
     {% if not inline %}id="{{node.markup_id}}" data-permalink-section{% endif %}

--- a/regulations/templates/regulations/tree.html
+++ b/regulations/templates/regulations/tree.html
@@ -1,3 +1,4 @@
+{% load formatting %}
 {% comment %}
     Template for inner paragraphs of a reg section
 {% endcomment %}
@@ -15,10 +16,16 @@
 </p>
 {% endif %}
 {% if node.children %}
-<ol class="level-{{node.children.0.list_level}}" 
-    type="{{node.children.0.list_type}}">
+<ol class="level-{{node.children.0.list_level}} {% if node.marker == 'none' or node.marker == '' %}markerless{% endif %}"
+    marker="{{ node.marker }}"
+    {% if node.children.0.marker %}
+        type="{{node.children.0.marker|format_marker}}"
+    {% else %}
+        type="{{node.children.0.list_type}}"
+    {% endif %}>
+
     {% for c in node.children %}
-        {%with node=c template_name="regulations/tree-with-wrapper.html" %}
+        {% with node=c template_name="regulations/tree-with-wrapper.html" %}
             {% include template_name %}
         {% endwith %}
     {% endfor %}

--- a/regulations/templatetags/formatting.py
+++ b/regulations/templatetags/formatting.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+@register.filter
+def format_marker(marker_string):
+    marker = marker_string.replace('(', '')
+    marker = marker.replace(')', '')
+    marker = marker.replace('.', '')
+
+    return marker


### PR DESCRIPTION
This PR uses the markers specified in the XML to render ordered lists if those markers are available. If not, default to the previous method.