### PR TITLE
Eslint fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,6 @@ rules:
   no-cond-assign: 0
   no-comma-dangle: 2
   no-console: 1
-  no-extra-parens: 2
   no-irregular-whitespace: 2
   no-reserved-keys: 2
 
@@ -42,17 +41,14 @@ rules:
 
 
   # Stylistic issues
-  brace-style: 2
   camelcase: 0
   new-cap: 0
   no-mixed-spaces-and-tabs: 2
-  no-lonely-if: 2
   no-space-before-semi: 2
   no-underscore-dangle: 0
   space-after-keywords: 2
   no-trailing-spaces: 2
   space-in-brackets: [2, never]
-  space-infix-ops: 2
   quotes: [2, single]
   semi: [2, "always"]
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -59,7 +59,6 @@ rules:
 
   # Outstanding issues
   no-unused-vars: 0
-  no-extend-native: 0
   valid-typeof: 0
   brace-style: 0
   no-multi-spaces: 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,6 @@ rules:
   curly: 2
   no-alert: 2
   no-eval: 2
-  no-extend-native: 2
   no-with: 2
 
   # Variables
@@ -59,6 +58,7 @@ rules:
 
   # Outstanding issues
   no-unused-vars: 0
+  no-extend-native: 1
   valid-typeof: 0
   brace-style: 0
   no-multi-spaces: 0


### PR DESCRIPTION
This removes the duplicate ruleset and changes no-extend-native to throw a warning.