### PR TITLE
use version to fetch SxS analyses, rather than notice_id

### DIFF
--- a/regulations/views/partial_sxs.py
+++ b/regulations/views/partial_sxs.py
@@ -89,8 +89,8 @@ class ParagraphSXSView(TemplateView):
         label_id = context['label_id']
         part = label_id.split('-')[0]
         notice_id = context['notice_id']
-        version = context['version']
         fr_page = context.get('fr_page')
+        version = context.get('version', notice_id)
 
         notice = generator.get_notice(part, version)
         if not notice:

--- a/regulations/views/partial_sxs.py
+++ b/regulations/views/partial_sxs.py
@@ -89,9 +89,10 @@ class ParagraphSXSView(TemplateView):
         label_id = context['label_id']
         part = label_id.split('-')[0]
         notice_id = context['notice_id']
+        version = context['version']
         fr_page = context.get('fr_page')
 
-        notice = generator.get_notice(part, notice_id)
+        notice = generator.get_notice(part, version)
         if not notice:
             raise error_handling.MissingContentException()
         notice = convert_to_python(notice)


### PR DESCRIPTION
One notice can produce several versions, so we should fetch SxS by the version number rather than the notice.