### PR TITLE
Fetch SxS by version or notice_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,8 @@ regulations-core/
 style.css.map
 .coverage
 regulations.egg-info
-
+build/
+dist/
 
 # docs output
 docs/_build

--- a/regulations/generator/generator.py
+++ b/regulations/generator/generator.py
@@ -20,6 +20,7 @@ from layers.paragraph_markers import ParagraphMarkersLayer
 from layers.toc_applier import TableOfContentsLayer
 from layers.graphics import GraphicsLayer
 from layers.diff_applier import DiffApplier
+from layers.utils import convert_to_python
 from html_builder import HTMLBuilder
 import notices
 
@@ -217,6 +218,14 @@ def get_sxs(label_id, notice, fr_page=None):
     relevant_sxs = notices.find_label_in_sxs(all_sxs, label_id, fr_page)
 
     return relevant_sxs
+
+
+def get_notice_and_sxs(part, notice_id, label_id, fr_page):
+    """ Wrap calls to get_notice() and get_sxs() """
+    notice = get_notice(part, notice_id)
+    notice = convert_to_python(notice)
+    paragraph_sxs = get_sxs(label_id, notice, fr_page)
+    return notice, paragraph_sxs
 
 
 def get_diff_json(regulation, older, newer):

--- a/regulations/views/partial_sxs.py
+++ b/regulations/views/partial_sxs.py
@@ -92,15 +92,15 @@ class ParagraphSXSView(TemplateView):
         fr_page = context.get('fr_page')
         version = context.get('version', notice_id)
 
-        notice = generator.get_notice(part, version)
-        if not notice:
-            raise error_handling.MissingContentException()
-        notice = convert_to_python(notice)
-
-        paragraph_sxs = generator.get_sxs(label_id, notice, fr_page)
-
-        if paragraph_sxs is None:
-            raise error_handling.MissingContentException()
+        # Try first to get the notice and SxS with the version.
+        notice, paragraph_sxs = generator.get_notice_and_sxs(part, version,
+                label_id, fr_page)
+        if notice is None or paragraph_sxs is None:
+            # If that didn't work, try again with the notice_id
+            notice, paragraph_sxs = generator.get_notice_and_sxs(part, 
+                    notice_id, label_id, fr_page)
+            if notice is None or paragraph_sxs is None:
+                raise error_handling.MissingContentException()
 
         notices.add_depths(paragraph_sxs, 3)
 


### PR DESCRIPTION
This PR fixes an issue where SxS fetching by version would fail with older data that’s only associated with notice_ids (without the version date extension).

This should work now with both old eCFR parser-generated JSON as well as RegML parser-generated JSON.

@grapesmoker @hillaryj @ascott1 