### PR TITLE
Addition tracking clean up

### DIFF
--- a/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/drawer-tabs-view.js
@@ -76,10 +76,10 @@ var DrawerTabsView = Backbone.View.extend({
         // only send click event if there was an actual click
         if (e) {
             if ($(e.target).hasClass('open')) {
-                GAEvents.sendEvent('drawer:open', 'drawer');
+                GAEvents.sendEvent('drawer', 'drawer:open');
             }
             else {
-                GAEvents.sendEvent('drawer:close', 'drawer');
+                GAEvents.sendEvent('drawer', 'drawer:close');
             }
         }
     },

--- a/regulations/static/regulations/js/source/views/main/reg-view.js
+++ b/regulations/static/regulations/js/source/views/main/reg-view.js
@@ -187,16 +187,14 @@ var RegView = ChildView.extend({
         else {
             // close old definition, if there is one
             SidebarEvents.trigger('definition:close');
-            GAEvents.sendEvent('definition:close', defId);
-
             // open new definition
             this.setActiveTerm($link);
             SidebarEvents.trigger('definition:open', {
                 'id': defId,
                 'term': term
             });
-            GAEvents.sendEvent('definition:open', defId);
         }
+        GAEvents.sendEvent('definition:open', term);
     },
 
     // content section key term link click handler

--- a/regulations/static/regulations/js/source/views/main/reg-view.js
+++ b/regulations/static/regulations/js/source/views/main/reg-view.js
@@ -243,10 +243,10 @@ var RegView = ChildView.extend({
         buttonText.html(section.hasClass('open') ? 'Hide' : 'Show');
 
         if (section.hasClass('open') && section.hasClass('inline-interpretation')) {
-            GAEvents.sendEvent('interexpandables:open', context);
+            GAEvents.sendEvent('interpexpandables:open', context.to);
         }
         else if (section.hasClass('inline-interpretation')) {
-            GAEvents.sendEvent('interexpandables:close', context);
+            GAEvents.sendEvent('interpexpandables:close', context.to);
         }
 
         return this;

--- a/regulations/static/regulations/js/source/views/sidebar/definition-view.js
+++ b/regulations/static/regulations/js/source/views/sidebar/definition-view.js
@@ -78,6 +78,7 @@ var DefinitionView = SidebarModuleView.extend({
         $('.definition.active').focus();
 
         MainEvents.trigger('definition:close');
+        GAEvents.sendEvent('definition:close', this.term);
         this.remove();
     },
 

--- a/regulations/static/regulations/js/source/views/sidebar/sidebar-view.js
+++ b/regulations/static/regulations/js/source/views/sidebar/sidebar-view.js
@@ -178,9 +178,9 @@ var SidebarView = Backbone.View.extend({
         Helpers.toggleExpandable($expandable, 400);
 
         if ($expandable.hasClass('open')) {
-          GAEvents.sendEvent('expandables:open', 'sidebar expandable');
+          GAEvents.sendEvent('expandables:open', $expandable.data('expandable'));
         } else {
-          GAEvents.sendEvent('expandables:close', 'sidebar expandable');
+          GAEvents.sendEvent('expandables:close', $expandable.data('expandable'));
         }
 
     },

--- a/regulations/static/regulations/js/source/views/sidebar/sidebar-view.js
+++ b/regulations/static/regulations/js/source/views/sidebar/sidebar-view.js
@@ -178,9 +178,9 @@ var SidebarView = Backbone.View.extend({
         Helpers.toggleExpandable($expandable, 400);
 
         if ($expandable.hasClass('open')) {
-          GAEvents.sendEvent('expandables:open', $expandable.data('expandable'));
+          GAEvents.sendEvent('sidebarexpanable:open', $expandable.data('expandable'));
         } else {
-          GAEvents.sendEvent('expandables:close', $expandable.data('expandable'));
+          GAEvents.sendEvent('sidebarexpanable:close', $expandable.data('expandable'));
         }
 
     },

--- a/regulations/templates/regulations/generic_help.html
+++ b/regulations/templates/regulations/generic_help.html
@@ -1,4 +1,4 @@
-<header class="expandable group">
+<header class="expandable group" data-expandable="help-expandable">
     <h4 tabindex="0">Help</h4>
     <a href="#" tabindex="0"><span class="icon-text">Show/Hide Contents</span></a>
 </header>

--- a/regulations/templates/regulations/sidebar.html
+++ b/regulations/templates/regulations/sidebar.html
@@ -1,7 +1,7 @@
 {% load static from staticfiles %}
 
 <section id="sxs-list" class="regs-meta">
-    <header id="sxs-expandable-header" class="expandable sxs-expand group">
+    <header id="sxs-expandable-header" class="expandable sxs-expand group" data-expandable="sxs-expandable">
         <h4 tabindex="0">Section-by-section Analysis</h4>
         <a href="#" tabindex="0"><span class="icon-text">Show/Hide Contents</span></a>
     </header>


### PR DESCRIPTION
This:

- Detects which sidebar expandable is toggled (help vs. sxs)
- Only sends the relevant section when an inline interpretation is expanded
- Renames the sidebar expandable tracking events
- Only detects a defined term is closed when the user clicks the "close" button (rather than when a user opens a new term)
- Tracks the name of the term opened/closed rather than the term's `id`
- Changes the naming of the drawer toggle tracking to match other events

## Review

@willbarton 

## Gif

![Spying Alf](http://i.giphy.com/pWBz26C8pAATK.gif)