### PR TITLE
Track TOC clicks rather than opened sections

### DIFF
--- a/regulations/static/regulations/js/source/views/drawer/toc-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/toc-view.js
@@ -8,6 +8,7 @@ var MainEvents = require('../../events/main-events');
 var DrawerEvents = require('../../events/drawer-events');
 var HeaderEvents = require('../../events/header-events');
 var Resources = require('../../resources.js');
+var GAEvents = require('../../events/ga-events');
 Backbone.$ = $;
 
 var TOCView = Backbone.View.extend({
@@ -71,6 +72,7 @@ var TOCView = Backbone.View.extend({
         var sectionId = $(e.currentTarget).data('section-id');
         DrawerEvents.trigger('section:open', sectionId);
         MainEvents.trigger('section:open', sectionId, {}, 'reg-section');
+        GAEvents.sendEvent('toc:click', sectionId);
     },
 
     sendDiffClickEvent: function(e) {

--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -8,7 +8,6 @@ var HeaderEvents = require('../../events/header-events');
 var DrawerEvents = require('../../events/drawer-events');
 var Helpers = require('../../helpers');
 var MainEvents = require('../../events/main-events');
-var GAEvents = require('../../events/ga-events');
 Backbone.$ = $;
 
 var ChildView = Backbone.View.extend({
@@ -32,9 +31,6 @@ var ChildView = Backbone.View.extend({
                 }
 
                 this.route(this.options);
-
-                GAEvents.sendEvent('section:open', this.options.id);
-
                 this.attachWayfinding();
                 this.render();
             }


### PR DESCRIPTION
As advertised. This removes the `section:open` call which often fired a duplicate event (such as navigate to a section from a defined term) and adds tracking for section clicks in the table of contents.

## Review

@willbarton 