### PR TITLE
Track internal citation and clean up definition views

### DIFF
--- a/regulations/static/regulations/js/source/views/main/reg-view.js
+++ b/regulations/static/regulations/js/source/views/main/reg-view.js
@@ -21,7 +21,8 @@ var RegView = ChildView.extend({
 
     events: {
         'click .definition': 'termLinkHandler',
-        'click .inline-interp-header': 'expandInterp'
+        'click .inline-interp-header': 'expandInterp',
+        'click .citation': 'logCitation'
     },
 
     initialize: function() {
@@ -279,6 +280,11 @@ var RegView = ChildView.extend({
         // require inside of the loadImages function to accomodate testing dependencies
         var unveil = require('unveilable');
         $('.reg-image').unveil();
+    },
+
+    logCitation: function(e) {
+        var sectionId = $(e.target).data('section-id');
+        GAEvents.sendEvent('link:followCitation', sectionId);
     }
 });
 

--- a/regulations/static/regulations/js/source/views/sidebar/definition-view.js
+++ b/regulations/static/regulations/js/source/views/sidebar/definition-view.js
@@ -78,8 +78,9 @@ var DefinitionView = SidebarModuleView.extend({
         $('.definition.active').focus();
 
         MainEvents.trigger('definition:close');
-        GAEvents.sendEvent('definition:close', this.term);
         this.remove();
+
+        GAEvents.sendEvent('definition:close', this.term);
     },
 
     updateDefinition: function(e) {
@@ -181,6 +182,7 @@ var DefinitionView = SidebarModuleView.extend({
         this.stopListening();
         this.off();
         this.$el.html('');
+        this.$el.unbind();
 
         return this;
     }


### PR DESCRIPTION
This PR continues to improve our custom tag manager tracking by:

1. Tracking internal citation clicks
2. Prevent "ghost" tracking calls that were happening in the definition view where the content of previously accessed definitions were also being called by unbinding the jQuery events when the definition is removed.

## Review

@willbarton 