### PR TITLE
Additional tag manager tracking

### DIFF
--- a/regulations/static/regulations/js/source/views/drawer/search-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/search-view.js
@@ -4,12 +4,14 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var Router = require('../../router');
 var MainEvents = require('../../events/main-events');
+var GAEvents = require('../../events/ga-events');
 Backbone.$ = $;
 
 var SearchView = Backbone.View.extend({
     el: '#search',
 
     events: {
+        'change #version-select': 'logSearchVersion',
         'submit': 'openSearchResults'
     },
 
@@ -19,6 +21,11 @@ var SearchView = Backbone.View.extend({
         if (Router.hasPushState === false) {
             this.events = {};
         }
+    },
+
+    logSearchVersion: function(e) {
+        var version = $(e.target).val();
+        GAEvents.sendEvent('searchVersion:change', version);
     },
 
     openSearchResults: function(e) {

--- a/regulations/static/regulations/js/source/views/main/reg-view.js
+++ b/regulations/static/regulations/js/source/views/main/reg-view.js
@@ -22,7 +22,7 @@ var RegView = ChildView.extend({
     events: {
         'click .definition': 'termLinkHandler',
         'click .inline-interp-header': 'expandInterp',
-        'click .citation': 'logCitation'
+        'click .internal': 'logCitation'
     },
 
     initialize: function() {
@@ -283,8 +283,12 @@ var RegView = ChildView.extend({
     },
 
     logCitation: function(e) {
-        var sectionId = $(e.target).data('section-id');
-        GAEvents.sendEvent('link:followCitation', sectionId);
+        var $e = $(e.target);
+
+        if ($e.hasClass('citation')) {
+            GAEvents.sendEvent('link:followCitation', $e.data('section-id'));
+        }
+
     }
 });
 


### PR DESCRIPTION
- Track the select changes in the search history
- Update to only track internal citation links that put users in a new section (excludes things like definitions)

## Review

@willbarton 