### PR TITLE
Appendix marker styles

### DIFF
--- a/regulations/static/regulations/css/less/overrides.less
+++ b/regulations/static/regulations/css/less/overrides.less
@@ -21,3 +21,55 @@ but we want to hide them in the wayfinding header.
         }
     }
 }
+
+/*
+Appendix Marker Overrides
+=========================
+In regs that are transformed using the original parsing process,
+rather than based on RegML, there are inconsistencies in the Appendix markers.
+These styles normalize those. Once Regulations D, G, and H are moved to the
+RegML process these overrides will need to be removed.
+*/
+
+.content-1004-A,
+.content-1007-A,
+.content-1008-A,
+.content-1008-B,
+.content-1008-C,
+.content-1008-D, {
+
+    .appendix-section {
+        .stripped-marker {
+            display: inline-block;
+            margin-left: -16px;
+            margin-right: 4px;
+        }
+    }
+
+    .appendix-section .inline-interpretation-content .stripped-marker {
+        margin-left: -20px;
+        width: 24px;
+    }
+
+    .appendix-section {
+      .key-term {
+          display: inline-block;
+      }
+    }
+
+    @media only screen and ( max-width: 780px ) {
+
+
+        .appendix-section .stripped-marker {
+          display: inline-block;
+          float: left;
+          margin-left: 0;
+          width: auto;
+          padding-right: 4px;
+        }
+
+        .appendix-section ol {
+            padding: 0;
+        }
+    }
+}

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -409,18 +409,6 @@ The `<ol>` tag needs to have the appropriate list type applied
   display: none;
 }
 
-// .appendix-section {
-//   .stripped-marker {
-//     display: inline-block;
-//     margin-left: -16px;
-//     margin-right: 4px;
-//   }
-// }
-// .appendix-section .inline-interpretation-content .stripped-marker {
-//     margin-left: -20px;
-//     width: 24px;
-// }
-
 /* remove paragraph markers that have the markerless class */
 .markerless {
   list-style-type: none;
@@ -448,12 +436,6 @@ except in the appendix where we use inline-block to accomodate the marker styles
 .key-term {
     display: block;
 }
-//
-// .appendix-section {
-//   .key-term {
-//     display: inline-block;
-//   }
-// }
 
 /*  Level-1 Key-Terms
     -----------------

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -395,10 +395,10 @@ The `<ol>` tag needs to have the appropriate list type applied
 .main-content ol, dfn, .stripped-marker {
   .avenir-next-demi;
 }
-
-.appendix-section ol {
-  list-style-type: none;
-}
+//
+// .appendix-section ol {
+//   list-style-type: none;
+// }
 
 .main-content p {
   font-family: @body-font;
@@ -409,17 +409,17 @@ The `<ol>` tag needs to have the appropriate list type applied
   display: none;
 }
 
-.appendix-section {
-  .stripped-marker {
-    display: inline-block;
-    margin-left: -16px;
-    margin-right: 4px;
-  }
-}
-.appendix-section .inline-interpretation-content .stripped-marker {
-    margin-left: -20px;
-    width: 24px;
-}
+// .appendix-section {
+//   .stripped-marker {
+//     display: inline-block;
+//     margin-left: -16px;
+//     margin-right: 4px;
+//   }
+// }
+// .appendix-section .inline-interpretation-content .stripped-marker {
+//     margin-left: -20px;
+//     width: 24px;
+// }
 
 /* remove paragraph markers that have the markerless class */
 .markerless {
@@ -448,12 +448,12 @@ except in the appendix where we use inline-block to accomodate the marker styles
 .key-term {
     display: block;
 }
-
-.appendix-section {
-  .key-term {
-    display: inline-block;
-  }
-}
+//
+// .appendix-section {
+//   .key-term {
+//     display: inline-block;
+//   }
+// }
 
 /*  Level-1 Key-Terms
     -----------------
@@ -713,18 +713,18 @@ pre {
     Appendix Content
     =====================
     */
-
-    .appendix-section .stripped-marker {
-      display: inline-block;
-      float: left;
-      margin-left: 0;
-      width: auto;
-      padding-right: 4px;
-    }
-
-    .appendix-section ol {
-        padding: 0;
-    }
+    //
+    // .appendix-section .stripped-marker {
+    //   display: inline-block;
+    //   float: left;
+    //   margin-left: 0;
+    //   width: auto;
+    //   padding-right: 4px;
+    // }
+    //
+    // .appendix-section ol {
+    //     padding: 0;
+    // }
 }
 
 @media only screen and ( max-width: 1100px ) {

--- a/regulations/templates/regulations/appendix.html
+++ b/regulations/templates/regulations/appendix.html
@@ -1,14 +1,14 @@
 {% load formatting %}
 {% comment %}
-    Display an appendix section. 
+    Display an appendix section.
 {% endcomment %}
 
 {% if c.node_type == "appendix" %}
-    <section id="{{c.markup_id}}" class="appendix-section section-focus" data-base-version="{{version}}" data-page-type="appendix" {% if newer_version %}data-newer-version="{{newer_version}}"{% endif %}>
+    <section id="{{c.markup_id}}" class="appendix-section section-focus content-{{c.markup_id}}" data-base-version="{{version}}" data-page-type="appendix" {% if newer_version %}data-newer-version="{{newer_version}}"{% endif %}>
         <h2 class="appendix-title" tabindex="0"> {{c.header|safe}} </h2>
          {%if c.TOC %}
             {% with nav_class='appendix-nav' toc_items=c.TOC %}
-               {% include "regulations/toc.html" %} 
+               {% include "regulations/toc.html" %}
             {% endwith %}
          {%endif%}
 
@@ -20,8 +20,8 @@
             <h3 class="appendix-heading{% if not level_one.text and not level_one.children %} empty-header{% endif %}" tabindex="0"> {{level_one.header|safe}} </h3>
 
             {% if level_one.marked_up %}
-            <p> 
-                {{level_one.marked_up|safe|linebreaksbr}} 
+            <p>
+                {{level_one.marked_up|safe|linebreaksbr}}
             </p>
             {% endif %}
 


### PR DESCRIPTION
This removes the appendix marker styles and treats them as though they were reg text. 

Regulations that were transformed pre-RegML and have markers in the appendix have specific style overrides. I will leave an issue in this repo detailing that. It's also important that these styles don't go to production before a RegML version of Reg Z.

Outstanding issues:

## Reg Z:

- Appendix E (intro paragraph causes next paragraph to start as "b." should be "1.")
- Appendix F (same issue as Appendix E)
- Appendix L ("Loan Periods" should be a "b." level)

## Reg C:

- Appendix B (intro paragraph causes next paragraph to start as "b." should be "1.")

## Reg DD:

- Appendix B (inline interpretation placed at the beginning of the section casuses the markers to start at "b." should be "a.")