### PR TITLE
Remove indent from markerless content

### DIFF
--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -312,7 +312,6 @@ a:visited {
 */
 
 .section-number,
-.appendix-heading,
 .supplement-section h3 {
     font-size: 1.8125em; /* 29px / 16 */
     .avenir-next-demi;
@@ -418,7 +417,8 @@ The `<ol>` tag needs to have the appropriate list type applied
   >h4,
   >p,
   >img,
-  >.table-wrap, {
+  >.table-wrap,
+  >ol {
     margin-left: -1em;
   }
 }

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -418,8 +418,7 @@ The `<ol>` tag needs to have the appropriate list type applied
         >h4,
         >p,
         >img,
-        >.table-wrap,
-        >ol {
+        >.table-wrap {
             margin-left: -1.2em;
         }
     }

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -412,15 +412,17 @@ The `<ol>` tag needs to have the appropriate list type applied
 .markerless {
   list-style-type: none;
 
-  /* don't indent the markerless headings, paragraphs, tables, and images */
-  >h3,
-  >h4,
-  >p,
-  >img,
-  >.table-wrap,
-  >ol {
-    margin-left: -1em;
-  }
+    /* don't indent the markerless headings, paragraphs, tables, and images */
+    @media screen and (min-width: 600px) {
+        >h3,
+        >h4,
+        >p,
+        >img,
+        >.table-wrap,
+        >ol {
+            margin-left: -1.2em;
+        }
+    }
 }
 
 

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -413,8 +413,12 @@ The `<ol>` tag needs to have the appropriate list type applied
 .markerless {
   list-style-type: none;
 
-  /* don't indent the markerless paragraph */
-  >p {
+  /* don't indent the markerless headings, paragraphs, tables, and images */
+  >h3,
+  >h4,
+  >p,
+  >img,
+  >.table-wrap, {
     margin-left: -1em;
   }
 }


### PR DESCRIPTION
This explicitly removes the indent from content that appears inside of markerless `<li>` tags in the appendices to prevent any odd indentation.