### PR TITLE
add ignore attributes for google tag manager

### DIFF
--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -37,13 +37,13 @@
         <a href="#" id="panel-link" class="toc-toggle panel-slide"><span class="icon-text">Navigation</span></a>
         <ul class="drawer-toggles">
             {% block sidebar-toc-link %}
-            <li><a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Table of Contents"><span class="icon-text">Table of Contents</span><span class="cf-icon cf-icon-table-of-contents"></span></a></li>
+            <li><a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Table of Contents" data-gtm_ignore="true"><span class="icon-text">Table of Contents</span><span class="cf-icon cf-icon-table-of-contents"></span></a></li>
             {% endblock %}
             {% block sidebar-history-link %}
-            <li><a href="#timeline" id="timeline-link" class="toc-nav-link" title="Regulation Timeline"><span class="icon-text">Regulation Timeline</span><span class="cf-icon cf-icon-history"></span></a></li>
+            <li><a href="#timeline" id="timeline-link" class="toc-nav-link" title="Regulation Timeline" data-gtm_ignore="true"><span class="icon-text">Regulation Timeline</span><span class="cf-icon cf-icon-history"></span></a></li>
             {% endblock %}
             {% block sidebar-search-link %}
-            <li><a href="#search" id="search-link" class="toc-nav-link" title="Search"><span class="icon-text">Search</span><span class="cf-icon cf-icon-search"></span></a></li>
+            <li><a href="#search" id="search-link" class="toc-nav-link" title="Search"><span class="icon-text" data-gtm_ignore="true">Search</span><span class="cf-icon cf-icon-search"></span></a></li>
             {% endblock %}
         </ul>
     </div> <!-- /toc-head-->

--- a/regulations/templates/regulations/layers/definition_citation.html
+++ b/regulations/templates/regulations/layers/definition_citation.html
@@ -1,4 +1,4 @@
 {% comment %}
-    Links to definitions in the regulation text. 
+    Links to definitions in the regulation text.
 {% endcomment %}
-<a href="{{citation.url}}" class="citation definition" data-definition="{{citation.definition_reference}}" data-defined-term="{{citation.term}}">{{citation.label}}</a>
+<a href="{{citation.url}}" class="citation definition" data-definition="{{citation.definition_reference}}" data-defined-term="{{citation.term}}" data-gtm_ignore="true">{{citation.label}}</a>

--- a/regulations/templates/regulations/layers/internal_citation.html
+++ b/regulations/templates/regulations/layers/internal_citation.html
@@ -1,1 +1,1 @@
-<a href="{{citation.url}}" class="citation internal" data-section-id="{{citation.label_id}}">{{citation.label}}</a>
+<a href="{{citation.url}}" class="citation internal" data-section-id="{{citation.label_id}}" data-gtm_ignore="true">{{citation.label}}</a>

--- a/regulations/templates/regulations/partial-definition.html
+++ b/regulations/templates/regulations/partial-definition.html
@@ -31,7 +31,7 @@
 
         <a  href="{% url 'chrome_section_view' node.section_id version %}#{{node.label_id}}"
             class="continue-link full-def internal"
-            data-linked-section="{{node.label_id}}">{{formatted_label}}</a>
+            data-linked-section="{{node.label_id}}" data-gtm_ignore="true">{{formatted_label}}</a>
 
         {% if not node.children %}
             {% if node.interp %}
@@ -39,7 +39,7 @@
                 <a  href="{% url 'chrome_subterp_view' interp.section_id version %}#{{ interp.label_id }}"
                     data-linked-subsection="{{ interp.label_id }}"
                     data-linked-section="{{ interp.section_id }}"
-                    class="internal interp continue-link">Official Interpretation</a>
+                    class="internal interp continue-link" data-gtm_ignore="true">Official Interpretation</a>
                 {% endwith %}
             {% endif %}
         {% endif %}

--- a/regulations/templates/regulations/sidebar.html
+++ b/regulations/templates/regulations/sidebar.html
@@ -11,7 +11,7 @@
         <a class="what" href="{% url 'about' %}#related-info" aria-label="Link opens in a new window" target="_blank">(What's this?)</a>
         <ul class="sxs-list">
             {% for analysis in analyses %}
-                <li><a class="sidebar-full sxs-link" href="{% url 'chrome_sxs_view' analysis.label_id analysis.doc_number %}?from_version={{ version }}" data-sxs-paragraph-id="{{analysis.label_id}}" data-doc-number="{{analysis.doc_number}}">{{analysis.text}}<span class="cf-icon cf-icon-right"></span></a></li>
+                <li><a class="sidebar-full sxs-link" href="{% url 'chrome_sxs_view' analysis.label_id analysis.doc_number %}?from_version={{ version }}" data-sxs-paragraph-id="{{analysis.label_id}}" data-doc-number="{{analysis.doc_number}}" data-gtm_ignore="true">{{analysis.text}}<span class="cf-icon cf-icon-right"></span></a></li>
             {% endfor %}
         </ul>
     {% else %}

--- a/regulations/templates/regulations/toc-interps.html
+++ b/regulations/templates/regulations/toc-interps.html
@@ -3,7 +3,7 @@
 {% if item.sub_toc %}
     {% for item in item.sub_toc %}
         {% if item.is_subterp %}
-        <li><span><a href="{{item.url}}" data-section-id="{{item.section_id}}">
+        <li><span><a href="{{item.url}}" data-section-id="{{item.section_id}}" data-gtm_ignore="true">
             <span class="toc-interp-heading">Interpretations For</span>
             <span class="toc-section-marker">{{item.label|safe}}
             {% if item.sub_label %} - </span><span class="toc-interp-title">{{item.sub_label|safe}}</span>{% else %}</span>{% endif %}</a></span></li>

--- a/regulations/templates/regulations/toc-section.html
+++ b/regulations/templates/regulations/toc-section.html
@@ -1,1 +1,1 @@
-<li><a href="{{item.url}}" data-section-id="{{item.section_id}}" id="nav-{{item.section_id}}"><span class="toc-section-marker">§&nbsp;{{item.label}}</span> {{item.sub_label|safe}}</a></li>
+<li><a href="{{item.url}}" data-section-id="{{item.section_id}}" data-gtm_ignore="true" id="nav-{{item.section_id}}"><span class="toc-section-marker">§&nbsp;{{item.label}}</span> {{item.sub_label|safe}}</a></li>

--- a/regulations/templates/regulations/toc-subpart.html
+++ b/regulations/templates/regulations/toc-subpart.html
@@ -1,4 +1,4 @@
-<li data-subpart-heading><h3 class="subpart-heading" data-section-id="{{item.section_id}}" id="nav-{{item.section_id}}">{{item.label|safe|upper}} - <span class="subpart-subhead">{{item.sub_label|safe}}</span></h3></li>
+<li data-subpart-heading><h3 class="subpart-heading" data-section-id="{{item.section_id}}" data-gtm_ignore="true" id="nav-{{item.section_id}}">{{item.label|safe|upper}} - <span class="subpart-subhead">{{item.sub_label|safe}}</span></h3></li>
 
 {% if item.sub_toc %}
     {% for item in item.sub_toc %}

--- a/regulations/templates/regulations/toc.html
+++ b/regulations/templates/regulations/toc.html
@@ -20,7 +20,7 @@
                     {% if item.is_first_appendix %}
                         <li data-subpart-heading><h3 class="subpart-heading">Appendices</h3></li>
                     {% endif %}
-                    <li><a href="{{item.url}}" data-section-id="{{item.section_id}}"><span class="toc-section-marker">{{item.label|safe}}</span> {{item.sub_label|safe}}</a></li>
+                    <li><a href="{{item.url}}" data-section-id="{{item.section_id}}" data-gtm_ignore="true"><span class="toc-section-marker">{{item.label|safe}}</span> {{item.sub_label|safe}}</a></li>
                 {% endif %}
             {% endfor %}
         </ol>

--- a/regulations/tests/layers_definitions_tests.py
+++ b/regulations/tests/layers_definitions_tests.py
@@ -14,6 +14,6 @@ class DefinitionsLayerTest(TestCase):
                                             ['202', '3'], 'account')
 
         url = '<a href="#202-3" class="citation definition" '
-        url += 'data-definition="202-3" data-defined-term="account">'
+        url += 'data-definition="202-3" data-defined-term="account" data-gtm_ignore="true">'
         url += 'account</a>'
         self.assertEquals(definition_link, url)


### PR DESCRIPTION
This adds a data attribute that tells Google Tag Manager to ignore the default behavior for our custom tracking scripts.

## Review

@willbarton @grapesmoker or @hillaryj 