### PR TITLE
Don't cop out of interp introduction SxS

### DIFF
--- a/regulations/generator/node_types.py
+++ b/regulations/generator/node_types.py
@@ -64,10 +64,7 @@ def _l2t_interp(label):
         # Interpretation
         prefix = list(takewhile(lambda l: l != 'Interp', label))
         suffix = label[label.index('Interp')+1:]
-        if len(prefix) == 1 and suffix:
-            # Interpretation introduction; for now we cop out
-            return 'This Section'
-        elif len(prefix) == 1:
+        if len(prefix) == 1:
             return 'Supplement I to Part %s' % prefix[0]
         elif suffix:
             return 'Comment for %s-%s' % (label_to_text(prefix),

--- a/regulations/tests/node_types_tests.py
+++ b/regulations/tests/node_types_tests.py
@@ -65,7 +65,7 @@ class NodeTypesTest(TestCase):
                          label_to_text(['204', 'Subpart', 'C', 'Interp']))
         self.assertEqual('Interpretations for Appendices of Part 204',
                          label_to_text(['204', 'Appendices', 'Interp']))
-        self.assertEqual('This Section',
+        self.assertEqual('Supplement I to Part 204',
                          label_to_text(['204', 'Interp', 'h1']))
         self.assertEqual(
             'Appendix M2 to Part 204', label_to_text(['204', 'M2']))


### PR DESCRIPTION
This PR removes a test that would return “This Section” for an interpretations introduction instead of the supplement name.