### PR TITLE
Fix "about" URL name collision

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,6 @@ rules:
   no-cond-assign: 0
   no-comma-dangle: 2
   no-console: 1
-  no-extra-parens: 2
   no-irregular-whitespace: 2
   no-reserved-keys: 2
 
@@ -43,17 +42,14 @@ rules:
 
 
   # Stylistic issues
-  brace-style: 2
   camelcase: 0
   new-cap: 0
   no-mixed-spaces-and-tabs: 2
-  no-lonely-if: 2
   no-space-before-semi: 2
   no-underscore-dangle: 0
   space-after-keywords: 2
   no-trailing-spaces: 2
   space-in-brackets: [2, never]
-  space-infix-ops: 2
   quotes: [2, single]
   semi: [2, "always"]
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,6 @@ rules:
 
   # Outstanding issues
   no-unused-vars: 0
-  no-extend-native: 0
   valid-typeof: 0
   brace-style: 0
   no-multi-spaces: 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,6 @@ rules:
   curly: 2
   no-alert: 2
   no-eval: 2
-  no-extend-native: 2
   no-with: 2
 
   # Variables
@@ -55,6 +54,7 @@ rules:
 
   # Outstanding issues
   no-unused-vars: 0
+  no-extend-native: 1
   valid-typeof: 0
   brace-style: 0
   no-multi-spaces: 0

--- a/regulations/templates/regulations/generic_help.html
+++ b/regulations/templates/regulations/generic_help.html
@@ -5,7 +5,7 @@
 <div class="chunk expand-drawer">
     <div class="sidebar-subsection">
         <h5 class="help-title">Interface Help</h5>
-        <a class="what" href="{% url 'about' %}#navigation" target="_blank">(What's this?)</a>
+        <a class="what" href="{% url 'regulations_about' %}#navigation" target="_blank">(What's this?)</a>
 
         <ul class="help-list">
             <li><span class="cf-icon cf-icon-table-of-contents help-icon"></span>Table of contents</li>

--- a/regulations/templates/regulations/generic_universal.html
+++ b/regulations/templates/regulations/generic_universal.html
@@ -33,7 +33,7 @@
         <h2 class="hero-header">A platform to read regulations.</h2>
         <p class="hero-text">eRegulations makes regulations easier to find, read, and understand.</p>
 
-        <p class="read-more-link"><a href="{% url 'about' %}" class="go">About eRegulations</a></p>
+        <p class="read-more-link"><a href="{% url 'regulations_about' %}" class="go">About eRegulations</a></p>
       </div>
     </div> <!-- /.inner-wrap -->
 </div> <!-- /.hero -->
@@ -86,7 +86,7 @@
           official interpretations, highlighted defined terms, and a
           revision comparison view.</p>
 
-          <p><a href="{% url 'about' %}" class="go">Learn more about eRegulations&#8217; features</a></p>
+          <p><a href="{% url 'regulations_about' %}" class="go">Learn more about eRegulations&#8217; features</a></p>
         </div> <!-- /.primart -->
 
         {% block orgcontact %}

--- a/regulations/templates/regulations/main-header.html
+++ b/regulations/templates/regulations/main-header.html
@@ -12,7 +12,7 @@
         </a>
         <ul class="app-nav-list">
             <li class="app-nav-list-item"><a href="{% url 'universal_landing' %}">Regulations</a></li>
-            <li class="app-nav-list-item"><a href="{% url 'about' %}">About</a></li>
+            <li class="app-nav-list-item"><a href="{% url 'regulations_about' %}">About</a></li>
             <li class="app-nav-list-item logo-list-item">{% include "regulations/logo.html" %}</li>
             <li class="app-nav-list-item org-title">{% include "regulations/org-title.html" %}</li>
         </ul>

--- a/regulations/templates/regulations/sidebar.html
+++ b/regulations/templates/regulations/sidebar.html
@@ -8,14 +8,14 @@
     <div class="chunk expand-drawer">
     {% if analyses %}
         <h5 class="subtitle">Most Recent Analysis</h5>
-        <a class="what" href="{% url 'about' %}#related-info" target="_blank">(What's this?)</a>
+        <a class="what" href="{% url 'regulations_about' %}#related-info" target="_blank">(What's this?)</a>
         <ul class="sxs-list">
             {% for analysis in analyses %}
                 <li><a class="sidebar-full sxs-link" href="{% url 'chrome_sxs_view' analysis.label_id analysis.doc_number %}?from_version={{ version }}" data-sxs-paragraph-id="{{analysis.label_id}}" data-doc-number="{{analysis.doc_number}}">{{analysis.text}}<span class="cf-icon cf-icon-right"></span></a></li>
             {% endfor %}
         </ul>
     {% else %}
-        No analyses available for {{ human_label_id }} in this tool. <a class="what" href="{% url 'about' %}#related-info" target="_blank">(What's this?)</a>
+        No analyses available for {{ human_label_id }} in this tool. <a class="what" href="{% url 'regulations_about' %}#related-info" target="_blank">(What's this?)</a>
     {% endif %}
     </div>
 </section> <!-- /.regs-meta -->
@@ -23,7 +23,7 @@
      {% include "regulations/generic_help.html" %}
         <div class="sidebar-subsection">
             <h5 class="help-title">Textual Help</h5>
-            <a class="what" href="{% url 'about' %}#related-info" target="_blank">(What's this?)</a>
+            <a class="what" href="{% url 'regulations_about' %}#related-info" target="_blank">(What's this?)</a>
 
             <ul class="help-list">
                 <li class="group">

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -41,7 +41,7 @@ urlpatterns = patterns(
     '',
     url(r'^$', universal, name='universal_landing'),
     # about page
-    url(r'^about$', about, name='about'),
+    url(r'^about$', about, name='regulations_about'),
     # Redirect to version by date (by GET)
     # Example http://.../regulation_redirect/201-3-v
     url(r'^regulation_redirect/%s$' % paragraph_pattern, redirect_by_date_get,


### PR DESCRIPTION
We have the potential for a name collision with the "about" URL. This PR is a quick-fix for that while we (CFPB back-end as a group) address the issue more generally (i.e. start using Django namespaces for all our projects).

This PR is against a branch off the 0.9.1 release, and a 0.9.2 release will be created from that branch (since we have changes in master that we may not want to deploy just yet).

It does pull in a commit by @ascott1 that makes eslint happy.

@ascott1 @hillaryj @grapesmoker 