### PR TITLE
Add Z to marker overrides

### DIFF
--- a/regulations/static/regulations/css/less/overrides.less
+++ b/regulations/static/regulations/css/less/overrides.less
@@ -31,6 +31,24 @@ These styles normalize those. Once Regulations D, G, and H are moved to the
 RegML process these overrides will need to be removed.
 */
 
+// z overrides are temporary
+
+.content-1026-A,
+.content-1026-B,
+.content-1026-C,
+.content-1026-D,
+.content-1026-E,
+.content-1026-F,
+.content-1026-G,
+.content-1026-H,
+.content-1026-I,
+.content-1026-J,
+.content-1026-K,
+.content-1026-L,
+.content-1026-M1,
+.content-1026-M2,
+
+
 .content-1004-A,
 .content-1007-A,
 .content-1008-A,

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'bdist_egg': bdist_egg,
     },
     install_requires=[
-        'django==1.6',
+        'django==1.8',
         'lxml',
         'requests'
     ],


### PR DESCRIPTION
This bumps Django to 1.8 and temporarily adds reg Z to the appendix marker overrides.