### PR TITLE
Fix "about" URL name collision in master

### DIFF
--- a/regulations/templates/regulations/generic_help.html
+++ b/regulations/templates/regulations/generic_help.html
@@ -5,7 +5,7 @@
 <div class="chunk expand-drawer">
     <div class="sidebar-subsection">
         <h5 class="help-title">Interface Help</h5>
-        <a class="what" href="{% url 'about' %}#navigation" aria-label="Link opens in a new window" target="_blank">(What's this?)</a>
+        <a class="what" href="{% url 'regulations_about' %}#navigation" aria-label="Link opens in a new window" target="_blank">(What's this?)</a>
 
         <ul class="help-list">
             <li><span class="cf-icon cf-icon-table-of-contents help-icon"></span>Table of contents</li>

--- a/regulations/templates/regulations/generic_universal.html
+++ b/regulations/templates/regulations/generic_universal.html
@@ -33,7 +33,7 @@
         <h2 class="hero-header">A platform to read regulations.</h2>
         <p class="hero-text">eRegulations makes regulations easier to find, read, and understand.</p>
 
-        <p class="read-more-link"><a href="{% url 'about' %}" class="go">About eRegulations</a></p>
+        <p class="read-more-link"><a href="{% url 'regulations_about' %}" class="go">About eRegulations</a></p>
       </div>
     </div> <!-- /.inner-wrap -->
 </div> <!-- /.hero -->
@@ -86,7 +86,7 @@
           official interpretations, highlighted defined terms, and a
           revision comparison view.</p>
 
-          <p><a href="{% url 'about' %}" class="go">Learn more about eRegulations&#8217; features</a></p>
+          <p><a href="{% url 'regulations_about' %}" class="go">Learn more about eRegulations&#8217; features</a></p>
         </div> <!-- /.primart -->
 
         {% block orgcontact %}

--- a/regulations/templates/regulations/main-header.html
+++ b/regulations/templates/regulations/main-header.html
@@ -12,7 +12,7 @@
         </a>
         <ul class="app-nav-list">
             <li class="app-nav-list-item"><a href="{% url 'universal_landing' %}">Regulations</a></li>
-            <li class="app-nav-list-item"><a href="{% url 'about' %}">About</a></li>
+            <li class="app-nav-list-item"><a href="{% url 'regulations_about' %}">About</a></li>
             <li class="app-nav-list-item logo-list-item">{% include "regulations/logo.html" %}</li>
             <li class="app-nav-list-item org-title">{% include "regulations/org-title.html" %}</li>
         </ul>

--- a/regulations/templates/regulations/sidebar.html
+++ b/regulations/templates/regulations/sidebar.html
@@ -8,14 +8,14 @@
     <div class="chunk expand-drawer">
     {% if analyses %}
         <h5 class="subtitle">Most Recent Analysis</h5>
-        <a class="what" href="{% url 'about' %}#related-info" aria-label="Link opens in a new window" target="_blank">(What's this?)</a>
+        <a class="what" href="{% url 'regulations_about' %}#related-info" aria-label="Link opens in a new window" target="_blank">(What's this?)</a>
         <ul class="sxs-list">
             {% for analysis in analyses %}
                 <li><a class="sidebar-full sxs-link" href="{% url 'chrome_sxs_view' analysis.label_id analysis.doc_number %}?from_version={{ version }}" data-sxs-paragraph-id="{{analysis.label_id}}" data-doc-number="{{analysis.doc_number}}" data-gtm_ignore="true">{{analysis.text}}<span class="cf-icon cf-icon-right"></span></a></li>
             {% endfor %}
         </ul>
     {% else %}
-        No analyses available for {{ human_label_id }} in this tool. <a class="what" href="{% url 'about' %}#related-info" aria-label="Link opens in a new window" target="_blank">(What's this?)</a>
+        No analyses available for {{ human_label_id }} in this tool. <a class="what" href="{% url 'regulations_about' %}#related-info" aria-label="Link opens in a new window" target="_blank">(What's this?)</a>
     {% endif %}
     </div>
 </section> <!-- /.regs-meta -->
@@ -23,7 +23,7 @@
      {% include "regulations/generic_help.html" %}
         <div class="sidebar-subsection">
             <h5 class="help-title">Textual Help</h5>
-            <a class="what" href="{% url 'about' %}#related-info" aria-label="Link opens in a new window" target="_blank">(What's this?)</a>
+            <a class="what" href="{% url 'regulations_about' %}#related-info" aria-label="Link opens in a new window" target="_blank">(What's this?)</a>
 
             <ul class="help-list">
                 <li class="group">

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -41,7 +41,7 @@ urlpatterns = patterns(
     '',
     url(r'^$', universal, name='universal_landing'),
     # about page
-    url(r'^about$', about, name='about'),
+    url(r'^about$', about, name='regulations_about'),
     # Redirect to version by date (by GET)
     # Example http://.../regulation_redirect/201-3-v
     url(r'^regulation_redirect/%s$' % paragraph_pattern, redirect_by_date_get,


### PR DESCRIPTION
Second attempt: bring forward the fixes from #800 for the about page name.
