### PR TITLE
Bump the Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class bdist_egg(_bdist_egg):
 
 setup(
     name="regulations",
-    version="2.0.0",
+    version="2.1.0",
     packages=find_packages(),
     include_package_data=True,
     cmdclass={


### PR DESCRIPTION
This bumps the Python version to 2.1.0. Once this is merged, I’ll do a GitHub release of 2.1.0.