### PR TITLE
Old data with markers may not have node.marker, and will fail

### DIFF
--- a/regulations/templates/regulations/tree-with-wrapper.html
+++ b/regulations/templates/regulations/tree-with-wrapper.html
@@ -3,7 +3,7 @@
 {% endcomment %}
 
 <li
-    {% if node.marker == "none" or node.marker == "" or node.marker == None %}
+    {% if node.marker == "none" or node.marker == "" %}
         class="markerless"
     {% endif %}
     {% if not inline %}id="{{node.markup_id}}" data-permalink-section{% endif %}


### PR DESCRIPTION
Our pre-RegML data won’t necessarily have `node[‘marker’]`, and so the `node.marker == None` test can evaluate to True even when the paragraph should have a marker.

We’ll need to find an alternative solution for dealing with old data and cases where the marker not being present on the node means it actually should be markerless.