### PR TITLE
Fix error generated by diffs because of bad URL reverse lookup

### DIFF
--- a/regulations/templates/regulations/diff-chrome.html
+++ b/regulations/templates/regulations/diff-chrome.html
@@ -102,7 +102,7 @@ Comparison of {{meta.cfr_title_number}} CFR {{formatted_id}} | eRegulations
 {% block help-subsection %}
     <div class="sidebar-subsection">
         <h5 class="help-title">Comparison Help</h5>
-        <a class="what" href="{% url 'about' %}#timeline">(What's this?)</a>
+        <a class="what" href="{% url 'regulations_about' %}#timeline">(What's this?)</a>
 
         <ul class="help-list">
             <li>

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,10 @@ class bdist_wheel(_bdist_wheel):
         self.run_command('build_frontend')
         _bdist_wheel.run(self)
 
+
 setup(
     name="regulations",
-    version="2.1.1",
+    version="2.1.2",
     packages=find_packages(),
     include_package_data=True,
     cmdclass={


### PR DESCRIPTION
We changed the “about” view name to “regulations_about”. The diff template is still trying to use “about”, and erring. This PR fixes that and bumps the version for a new release.