### PR TITLE
Update requirements and setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+django>=1.8,<=1.8.99
+lxml
+requests
 # Import setup.py
 -e .

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,9 @@ setup(
         'bdist_wheel': bdist_wheel,
     },
     install_requires=[
-        'django==1.8',
+        'django>=1.8',
         'lxml',
-        'requests'
+        'requests',
     ],
     classifiers=[
         'License :: Public Domain',


### PR DESCRIPTION
This PR updates the requirements.txt and setup.py files.

First, it removes the version pin to a specific patch version of Django and makes it a range for 1.8.

Second, it moves the concrete requirements into the requirements.txt file rather than simply loading setup.py. The two sets of requirement specifications are conceptually different, and so we should treat them that way.