### PR TITLE
Overrides for Z

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ regulations.egg-info
 build/
 dist/
 .snyk
+eregsip/
 
 # docs output
 docs/_build

--- a/regulations/static/regulations/css/less/overrides.less
+++ b/regulations/static/regulations/css/less/overrides.less
@@ -32,23 +32,6 @@ RegML process these overrides will need to be removed.
 */
 
 // z overrides are temporary
-
-.content-1026-A,
-.content-1026-B,
-.content-1026-C,
-.content-1026-D,
-.content-1026-E,
-.content-1026-F,
-.content-1026-G,
-.content-1026-H,
-.content-1026-I,
-.content-1026-J,
-.content-1026-K,
-.content-1026-L,
-.content-1026-M1,
-.content-1026-M2,
-
-
 .content-1004-A,
 .content-1007-A,
 .content-1008-A,

--- a/regulations/static/regulations/css/less/overrides.less
+++ b/regulations/static/regulations/css/less/overrides.less
@@ -74,3 +74,20 @@ RegML process these overrides will need to be removed.
         }
     }
 }
+
+/*
+Section-by-section Analysis Overrides
+=====================================
+For Reg Z, we want to disable the SxS list entirely because there are 
+just too many errors in the SxS content. Once those errors are resolved
+we can reveal SxS again. Doing this ehre permits continued work on the 
+content while not exposing it through the UI.
+*/
+
+.secondary-content-1026 {
+
+    #sxs-list {
+        display: none;
+    }
+
+}

--- a/regulations/static/regulations/css/less/overrides.less
+++ b/regulations/static/regulations/css/less/overrides.less
@@ -31,7 +31,6 @@ These styles normalize those. Once Regulations D, G, and H are moved to the
 RegML process these overrides will need to be removed.
 */
 
-// z overrides are temporary
 .content-1004-A,
 .content-1007-A,
 .content-1008-A,

--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -170,7 +170,7 @@
 {% endblock %}
 
 {% block chrome-sidebar %}
-<div id="sidebar" class="secondary-content" role="complementary">
+<div id="sidebar" class="secondary-content secondary-content-{{reg_part}}" role="complementary">
     <div id="sidebar-content" class="sidebar-inner">
         <section id="definition"></section>
         {% block reg_sidebar %}

--- a/regulations/templates/regulations/generic_landing.html
+++ b/regulations/templates/regulations/generic_landing.html
@@ -29,7 +29,7 @@
 </div>
 
 
-<div id="sidebar" class="secondary-content">
+<div id="sidebar" class="secondary-content secondary-content-{{reg_part}}">
     <div id="sidebar-content" class="sidebar-inner">
     <section id="definition"></section>
     <section class="landing-sidebar">

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ class bdist_wheel(_bdist_wheel):
 
 setup(
     name="regulations",
-    version="2.1.2",
+    version="2.1.3",
     packages=find_packages(),
     include_package_data=True,
     cmdclass={


### PR DESCRIPTION
This PR removes overrides for the Z appendices that will no longer be needed for the RegML version of Z.

It also adds a reg-part-specific class allowing us to override secondary content, and adds a temporary override to hide the section-by-section analysis for Z.

This can wait to be merged until we’re ready for our next deployment.