### PR TITLE
Properly catch TypeErrors in redirect_by_date_get

### DIFF
--- a/regulations/tests/views_redirect_tests.py
+++ b/regulations/tests/views_redirect_tests.py
@@ -66,6 +66,11 @@ class ViewsRedirectTest(TestCase):
             redirect_by_date_get(request, 'lablab')
             self.assertTrue(handle.called)
 
+            handle.reset_mock()
+            request = RequestFactory().get('?year=2222')
+            redirect_by_date_get(request, 'lablab')
+            self.assertTrue(handle.called)
+
     def test_diff_redirect_bad_version(self):
         request = RequestFactory().get('?new_version=A+Bad+Version')
         response = diff_redirect(request, 'lablab', 'verver')

--- a/regulations/views/redirect.py
+++ b/regulations/views/redirect.py
@@ -50,7 +50,7 @@ def redirect_by_date_get(request, label_id):
 
         return redirect_by_date(request, label_id, "%04d" % year,
                                 "%02d" % month, "%02d" % day)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return handle_generic_404(request)
 
 


### PR DESCRIPTION
A 500 error occurs when querying a redirect URL without all date components (`year`, `month`, `day`), e.g.

http://www.consumerfinance.gov/eregulations/regulation_redirect/1004-4

This is because `TypeError`s aren't properly caught. See Python 2 [docs](https://docs.python.org/2.7/tutorial/errors.html#handling-exceptions):

> Note that the parentheses around this tuple are required, because except ValueError, e: was the syntax used for what is normally written as except ValueError as e: in modern Python (described below). The old syntax is still supported for backwards compatibility. This means except RuntimeError, TypeError is not equivalent to except (RuntimeError, TypeError): but to except RuntimeError as TypeError: which is not what you want.