### PR TITLE
Fix snyk errors in CI

### DIFF
--- a/frontendbuild.sh
+++ b/frontendbuild.sh
@@ -7,5 +7,5 @@ if [ ! -f config.json ]; then
 fi
 
 npm install
-npm test
+npm run test:js
 grunt

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   },
   "scripts": {
     "postinstall": "grunt",
-    "test": "grunt test-js && snyk test"
+    "test": "npm run test:js && npm run test:snyk",
+    "test:js": "grunt test-js",
+    "test:snyk": "snyk test"
   },
   "devDependencies": {
     "browserify": "9.0.3",


### PR DESCRIPTION
This breaks the snyk and js tests apart and only runs the js tests in `.frontendbuild.sh`