### PR TITLE
Catch common errors

### DIFF
--- a/regulations/views/chrome.py
+++ b/regulations/views/chrome.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from django.http import Http404
 from django.views.generic.base import TemplateView
 
 from regulations.generator import generator
@@ -100,10 +101,13 @@ class ChromeView(TemplateView):
         context['node_type'] = type_from_label(label_id_list)
 
         error_handling.check_regulation(reg_part)
-        self.set_chrome_context(context, reg_part, version)
 
-        self.check_tree(context)
-        self.add_main_content(context)
+        try:
+            self.set_chrome_context(context, reg_part, version)
+            self.check_tree(context)
+            self.add_main_content(context)
+        except (IndexError, TypeError):
+            raise Http404
 
         if self.has_sidebar:
             sidebar_view = SideBarView.as_view()

--- a/regulations/views/error_handling.py
+++ b/regulations/views/error_handling.py
@@ -89,8 +89,12 @@ def handle_missing_section_404(
     context = {
         'request_path': request.path,
         'reg_section':reg_section,
-        'effective_date':req_version['by_date']
     }
+    try:
+        context['effective_date'] = req_version['by_date']
+    except KeyError:
+        context['effective_date'] = ''
+
     context.update(extra_context)
 
     template = loader.get_template('regulations/missing_section_404.html')

--- a/regulations/views/partial_sxs.py
+++ b/regulations/views/partial_sxs.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseBadRequest
+from django.http import Http404
 from django.template import Context, loader
 from django.views.generic.base import TemplateView
 
@@ -93,11 +94,15 @@ class ParagraphSXSView(TemplateView):
         version = context.get('version', notice_id)
 
         # Try first to get the notice and SxS with the version.
-        notice, paragraph_sxs = generator.get_notice_and_sxs(part, version,
-                label_id, fr_page)
+        try:
+            notice, paragraph_sxs = generator.get_notice_and_sxs(part, version,
+                    label_id, fr_page)
+        except TypeError:
+            raise Http404
+
         if notice is None or paragraph_sxs is None:
             # If that didn't work, try again with the notice_id
-            notice, paragraph_sxs = generator.get_notice_and_sxs(part, 
+            notice, paragraph_sxs = generator.get_notice_and_sxs(part,
                     notice_id, label_id, fr_page)
             if notice is None or paragraph_sxs is None:
                 raise error_handling.MissingContentException()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="regulations",
-    version="2.1.5",
+    version="2.1.7",
     packages=find_packages(),
     include_package_data=True,
     setup_requires=['cfgov_setup==1.2',],


### PR DESCRIPTION
Most of the 500 errors regulations-site generates from two places and are generally either `TypeError`s or `IndexError`s. This PR wraps those two places in a `try`/`except` and throws a 404 when they’re encountered.

Additionally, we sometimes see a `KeyError` in the 404 error handling view. That is fixed here as well.