### PR TITLE
Catch more common errors

### DIFF
--- a/regulations/tests/views_chrome_tests.py
+++ b/regulations/tests/views_chrome_tests.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from django.conf import settings
-from django.http import HttpResponseGone
+from django.http import HttpResponseGone, Http404
 from django.test import Client, RequestFactory
 from mock import patch
 
@@ -36,8 +36,8 @@ class ViewsChromeTest(TestCase):
 
         view = FakeView()
         view.request = RequestFactory().get('/')
-        response = view.get(view.request, label_id='lab', version='ver')
-        self.assertEqual(404, response.status_code)
+        with self.assertRaises(Http404):
+            view.get(view.request, label_id='lab', version='ver')
 
     @patch('regulations.views.chrome.error_handling')
     @patch('regulations.views.chrome.generator')

--- a/regulations/tests/views_error_tests.py
+++ b/regulations/tests/views_error_tests.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from mock import patch
 
+from django.http import Http404
 from django.test import RequestFactory
 
 from regulations.views import error_handling
@@ -39,9 +40,8 @@ class ErrorHandlingTest(TestCase):
 
     def test_handle_generic_404(self):
         request = RequestFactory().get('/fake-path')
-        result = error_handling.handle_generic_404(request)
-        self.assertEqual(result.status_code, 404)
-        self.assertTrue('Regulation content not found' in result.content)
+        with self.assertRaises(Http404):
+            error_handling.handle_generic_404(request)
 
     @patch('regulations.views.error_handling.add_to_chrome')
     @patch('regulations.views.error_handling.api_reader')

--- a/regulations/tests/views_redirect_tests.py
+++ b/regulations/tests/views_redirect_tests.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from django.http import Http404
 from django.test import RequestFactory
 from mock import patch
 
@@ -73,8 +74,8 @@ class ViewsRedirectTest(TestCase):
 
     def test_diff_redirect_bad_version(self):
         request = RequestFactory().get('?new_version=A+Bad+Version')
-        response = diff_redirect(request, 'lablab', 'verver')
-        self.assertEqual(404, response.status_code)
+        with self.assertRaises(Http404):
+            diff_redirect(request, 'lablab', 'verver')
 
     @patch('regulations.views.redirect.fetch_grouped_history')
     def test_diff_redirect_order(self, fgh):

--- a/regulations/views/chrome.py
+++ b/regulations/views/chrome.py
@@ -48,9 +48,9 @@ class ChromeView(TemplateView):
             return error_handling.handle_missing_section_404(
                 request, e.label_id, e.version, e.context)
         except error_handling.MissingContentException, e:
-            return error_handling.handle_generic_404(request)
-        except TypeError:
-            return error_handling.handle_generic_404(request)
+            raise Http404
+        except (IndexError, TypeError):
+            raise Http404
 
     def _assert_good(self, response):
         if response.status_code != 200:

--- a/regulations/views/chrome.py
+++ b/regulations/views/chrome.py
@@ -49,6 +49,8 @@ class ChromeView(TemplateView):
                 request, e.label_id, e.version, e.context)
         except error_handling.MissingContentException, e:
             return error_handling.handle_generic_404(request)
+        except TypeError:
+            return error_handling.handle_generic_404(request)
 
     def _assert_good(self, response):
         if response.status_code != 200:

--- a/regulations/views/error_handling.py
+++ b/regulations/views/error_handling.py
@@ -33,12 +33,7 @@ class MissingSectionException(Exception):
 
 
 def handle_generic_404(request):
-    template = loader.get_template('regulations/generic_404.html')
-    context = {'request_path': request.path}
-    utils.add_extras(context)
-    body = template.render(RequestContext(
-        request, context))
-    return http.HttpResponseNotFound(body, content_type='text/html')
+    raise Http404
 
 
 def check_regulation(reg_part):

--- a/regulations/views/error_handling.py
+++ b/regulations/views/error_handling.py
@@ -33,7 +33,7 @@ class MissingSectionException(Exception):
 
 
 def handle_generic_404(request):
-    raise Http404
+    raise http.Http404
 
 
 def check_regulation(reg_part):

--- a/regulations/views/partial_search.py
+++ b/regulations/views/partial_search.py
@@ -1,3 +1,5 @@
+from urllib2 import HTTPError
+
 from django.http import HttpResponseBadRequest
 from django.template.defaultfilters import title
 
@@ -25,7 +27,10 @@ class PartialSearch(PartialView):
 
         kwargs['q'] = query
         kwargs['version'] = version
-        return super(PartialSearch, self).get(request, *args, **kwargs)
+        try:
+            return super(PartialSearch, self).get(request, *args, **kwargs)
+        except HTTPError:
+            return HttpResponseBadRequest("bad query or version")
 
     def add_prev_next(self, current_page, context):
         context['current'] = { 'page': current_page + 1,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="regulations",
-    version="2.1.7",
+    version="2.1.8",
     packages=find_packages(),
     include_package_data=True,
     setup_requires=['cfgov_setup==1.2',],


### PR DESCRIPTION
I've added a catch for Type/Index errors in two more locations where we consistently encounter them. 

I've also modified the custom 404 handler to simply throw an Http404 to let Django handle it. This will have the effect of presenting the same 404 page that we consistent do across cf.gov.

@chosak @grapesmoker 