### PR TITLE
allow setup.py to infer version number from git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup, find_packages
 
 setup(
     name="regulations",
-    version="2.1.8",
+    version_format='{tag}.dev{commitcount}+{gitsha}',
     packages=find_packages(),
     include_package_data=True,
-    setup_requires=['cfgov_setup==1.2',],
+    setup_requires=['cfgov_setup==1.2', 'setuptools-git-version==1.0.3'],
     frontend_build_script='frontendbuild.sh',
     install_requires=[
         'django>=1.8',


### PR DESCRIPTION
This should have been part of #830