### PR TITLE
Handle invalid SXS paragraphs with 404, not 500

### DIFF
--- a/regulations/tests/views_sxs_tests.py
+++ b/regulations/tests/views_sxs_tests.py
@@ -1,8 +1,10 @@
 from unittest import TestCase
 
 from django.template import Template
+from django.test import RequestFactory
 from mock import patch
 
+from regulations.views import error_handling
 from regulations.views.partial_sxs import *
 from regulations.generator.layers.utils import convert_to_python
 
@@ -157,3 +159,15 @@ class ParagrasphSXSViewTests(TestCase):
         self.assertTrue('sxs' in context)
         self.assertTrue('label' in context['sxs'])
 
+    @patch(
+        'regulations.views.partial_sxs.ParagraphSXSView.get_context_data',
+        side_effect=error_handling.MissingContentException
+    )
+    def test_missing_content_raises_404(self, get_context_data):
+        with self.assertRaises(Http404):
+            request = RequestFactory().get('/partial/sxs/1005-31-a/2012-1728')
+            ParagraphSXSView.as_view()(
+                request,
+                label_id='1005-31-a',
+                notice_id='2012-1728'
+            )

--- a/regulations/views/partial_sxs.py
+++ b/regulations/views/partial_sxs.py
@@ -29,15 +29,19 @@ class ParagraphSXSView(TemplateView):
                 'regulations/paragraph-sxs.html']
 
     def get(self, request, *args, **kwargs):
-        """Override this method so that we can grab the GET variables"""
+        """Override this method so that we can grab the GET variables
+        and properly handle any errors."""
         kwargs['version'] = request.GET.get('from_version')
         kwargs['back_url'] = SectionUrl.of(
             kwargs['label_id'].split('-'), kwargs['version'], sectional=True)
         kwargs['fr_page'] = request.GET.get('fr_page')
         if kwargs['fr_page'] and kwargs['fr_page'].isdigit():
             kwargs['fr_page'] = int(kwargs['fr_page'])
-        return super(ParagraphSXSView, self).get(request, *args,
-                                                 **kwargs)
+
+        try:
+            return super(ParagraphSXSView, self).get(request, *args, **kwargs)
+        except error_handling.MissingContentException as e:
+            raise Http404
 
     def further_analyses(self, label_id, notice_id, version,
             fr_page=None):


### PR DESCRIPTION
This change wraps the `MissingContentException` that gets thrown due to invalid SXS label requests so that it raises an `Http404` instead of causing a 500 error.

This can be tested by trying to manually access an invalid URL for a section for which no SXS analysis exists. These URLs should never be generated in a browser, but might be generated e.g. by URL hacking or by bots/crawlers.

An example URL that currently causes a problem for Reg E is:

http://localhost:8000/eregulations/partial/sxs/1005-31-a/2012-1728?from_version=2016-24506#1005-31-a

This raises a 500 because there's no `1005-31-a` label in the SXSanalysis, unlike a valid section like:

http://localhost:8000/eregulations/partial/sxs/1005-31/2012-1728?from_version=2016-24506#1005-31