### PR TITLE
Properly handle redirects to interp view

### DIFF
--- a/regulations/tests/views_redirect_tests.py
+++ b/regulations/tests/views_redirect_tests.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.test import RequestFactory
 from mock import patch
@@ -105,3 +106,20 @@ class ViewsRedirectTest(TestCase):
         response = diff_redirect(request, '1111-22', '3')
         self.assertTrue('diff/1111-22/1/3' in response['Location'])
         self.assertTrue('from_version=3' in response['Location'])
+
+    @patch('regulations.views.redirect.ApiReader')
+    def test_redirect_to_interp_view(self, ApiReader):
+        ApiReader.return_value.regversions.return_value = {'versions': [
+            {'by_date': '2017-01-01', 'version': 'aaa'},
+        ]}
+
+        request = RequestFactory().get('/')
+        label_id = '1001-Subpart-X-Interp'
+        response = redirect_by_date(request, label_id, '2017', '01', '01')
+        self.assertEqual(
+            (response.status_code, response['Location']),
+            (302, reverse('chrome_interp_view', kwargs={
+                'version': 'aaa',
+                'label_id': label_id,
+            }))
+        )

--- a/regulations/views/redirect.py
+++ b/regulations/views/redirect.py
@@ -28,7 +28,7 @@ def redirect_by_date(request, label_id, year, month, day):
     if last_version and len(label_parts) == 2:
         return redirect('chrome_section_view', label_id, last_version)
     elif last_version and label_parts[-1] == 'Interp':
-        return redirect('chrome_section_view', label_id, last_version)
+        return redirect('chrome_interp_view', label_id, last_version)
     elif last_version and len(label_parts) == 1:
         return redirect('chrome_regulation_view', label_id, last_version)
     elif last_version:


### PR DESCRIPTION
This PR fixes a bug with the redirect view for interp sections. When hitting a URL like

https://www.consumerfinance.gov/eregulations/regulation_redirect/1026-Subpart-C-Interp?year=2017&month=6&day=1

the redirect should go to the `chrome_interp_view` view, not the `chrome_section_view` view. In practice, this URL currently causes a `NoReverseMatch` 500 because `1026-Subpart-C` doesn't match the section regex required for the `chrome_section_view` URL pattern.