### PR TITLE
More robust handling of section titles

### DIFF
--- a/regulations/generator/title_parsing.py
+++ b/regulations/generator/title_parsing.py
@@ -44,6 +44,18 @@ def section(data):
         element['is_section'] = True
         element['label'] = '.'.join(data['index'])
         element['section_id'] = '-'.join(data['index'])
-        element['sub_label'] = re.search(
-            element['label'] + r'[^\w\[]*(.*)', data['title']).group(1)
+
+        # Due to inconsistencies in source data we need to be able to handle
+        # several different possible section title formats:
+        #
+        # 1003.2 Something
+        # § 1003.2 Something
+        # Something
+        # § Something
+        #
+        # In all of these cases, the sublabel should be "Something".
+        title_no_label = data['title'].split(element['label'])[-1]
+        sublabel_regex = re.compile(r'[^\w\[]*(.*)')
+        element['sub_label'] = sublabel_regex.search(title_no_label).group(1)
+
         return element

--- a/regulations/tests/title_parsing_tests.py
+++ b/regulations/tests/title_parsing_tests.py
@@ -32,3 +32,31 @@ class RegTest(TestCase):
 
         self.assertTrue(elements['is_section'])
         self.assertEquals('[Reserved]', elements['sub_label'])
+
+    def test_section_with_leading_symbol(self):
+        elements = title_parsing.section({
+            'index': ['204', '4'],
+            'title': '\xc2\xa7 204.4 Foo bar',
+        })
+        self.assertEqual(elements['sub_label'], 'Foo bar')
+
+    def test_section_with_leading_section(self):
+        elements = title_parsing.section({
+            'index': ['204', '4'],
+            'title': '204.4 Foo bar',
+        })
+        self.assertEqual(elements['sub_label'], 'Foo bar')
+
+    def test_section_without_leading_section(self):
+        elements = title_parsing.section({
+            'index': ['204', '4'],
+            'title': 'Foo bar',
+        })
+        self.assertEqual(elements['sub_label'], 'Foo bar')
+
+    def test_section_with_leading_symbol_but_without_leading_section(self):
+        elements = title_parsing.section({
+            'index': ['204', '4'],
+            'title': '\xc2\xa7 Foo bar',
+        })
+        self.assertEqual(elements['sub_label'], 'Foo bar')


### PR DESCRIPTION
Source regulation RegML seems to contain section titles with inconsistent formatting, for example:

- 1003.2 Something
- § 1003.2 Something
- Something
- § Something

In all of these cases, the section sublabel should be properly extracted as "Something". This change makes the sublabel extraction logic somewhat more robust and adds a few unit tests to verify functionality.

A real example of this kind of thing can be found in [this](https://github.com/cfpb/regulations-xml/blob/master/regulation/1005/2016-24506.xml) Reg E RegML file.