### PR TITLE
Handle missing diffs gracefully

### DIFF
--- a/regulations/views/diff.py
+++ b/regulations/views/diff.py
@@ -85,6 +85,10 @@ class PartialSectionDiffView(PartialView):
 
         builder = HTMLBuilder(*appliers)
         builder.tree = tree
+
+        if not builder.tree:
+            return error_handling.handle_generic_404(self.request)
+
         builder.generate_html()
 
         child_of_root = builder.tree


### PR DESCRIPTION
This commit fixes a 500 error that's caused by trying to hit an invalid or missing diff, e.g. one where the node requested is in neither of the two versions being diffed. An example URL that can be hit locally for Reg B is

http://localhost:8000/eregulations/diff/1002-99/2013-22752_20140101/2013-22752_20140118?from_version=2013-22752_20140118

This node doesn't exist in either of the two (unlike `1002-1`, which does), and currently causes a `KeyError` by looking for a missing `label` field in a generated node, which is actually empty.

This change detects if the built tree is empty, and, if so, just raises a 404 error instead.

Unfortunately, while it'd be nice to add unit tests for this, it's a little bit tricky because of the way this code is written. It'd require a larger refactor to write a test for this. This can be tested manually using the URL above.