### PR TITLE
Allow multiple dashes in section names

### DIFF
--- a/regulations/tests/urls_test.py
+++ b/regulations/tests/urls_test.py
@@ -33,3 +33,9 @@ class UrlTests(TestCase):
             args=('201-2', '2011-1738_20121011', '2012-22345_20131022'))
         self.assertEqual(
             r, '/diff/201-2/2011-1738_20121011/2012-22345_20131022')
+
+    def test_diff_url_supports_multiple_dashes(self):
+        r = reverse(
+            'chrome_section_diff_view',
+            args=('201-Interp-XYZ', '2011-1738', '2012-22345'))
+        self.assertEqual(r, '/diff/201-Interp-XYZ/2011-1738/2012-22345')

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -28,7 +28,7 @@ newer_version_pattern = meta_version % 'newer_version'
 notice_pattern = meta_version % 'notice_id'
 
 reg_pattern = r'(?P<label_id>[\d]+)'
-section_pattern = r'(?P<label_id>[\d]+[-][\w]+)'
+section_pattern = r'(?P<label_id>[\d]+[-][\w-]+)'
 interp_pattern = r'(?P<label_id>[-\d\w]+[-]Interp)'
 paragraph_pattern = r'(?P<label_id>[-\d\w]+)'
 subterp_pattern = r'(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)'


### PR DESCRIPTION
This commit modifies the expected URL pattern for reg section labels so that instead of supporting only e.g. "1005-a" it also supports sections like "1005-a-interp". This fixes some 500 errors that were being generated due to a "1005-Appendices-Interp" section in Reg E.

You can confirm that this works to view diffs in the most recent Reg E content in regulations-stub by hitting this URL locally:

http://localhost:8000/eregulations/diff/1005-2/2016-24506/2016-24503_20181001?from_version=2016-24506#1005-2-a

The section label is passed around the code in various places so it's possible that adding this flexibility might break something else downstream. All current unit tests pass with this change (`python manage.py test`), however, so I'd rather enable this (which seems like a reasonable assumption, unless there's some section naming guidelines somewhere that are being violated) and handle errors as they come up.