### PR TITLE
provide fallback when fetching subterps

### DIFF
--- a/regulations/generator/subterp.py
+++ b/regulations/generator/subterp.py
@@ -12,9 +12,7 @@ def filter_by_subterp(nodes, subterp_label, version):
     the range"""
     is_section = lambda n: n['label'][1].isdigit()
     not_section = lambda n: not is_section(n)
-
-    def is_app_section(node):
-        return re.search('^[A-Z]', node['label'][1]) is not None
+    is_app_section = lambda n: re.search('^[A-Z]', n['label'][1]) is not None
 
     if subterp_label[1:] == ['Subpart', 'Interp']:      # Empty part
         skip_intros = dropwhile(not_section, nodes)

--- a/regulations/generator/subterp.py
+++ b/regulations/generator/subterp.py
@@ -1,3 +1,4 @@
+import re
 from itertools import dropwhile, takewhile
 
 from regulations.generator.toc import fetch_toc
@@ -12,14 +13,16 @@ def filter_by_subterp(nodes, subterp_label, version):
     is_section = lambda n: n['label'][1].isdigit()
     not_section = lambda n: not is_section(n)
 
+    def is_app_section(node):
+        return re.search('^[A-Z]', node['label'][1]) is not None
+
     if subterp_label[1:] == ['Subpart', 'Interp']:      # Empty part
         skip_intros = dropwhile(not_section, nodes)
         sections = takewhile(is_section, skip_intros)
         return list(sections)
     elif subterp_label[1:] == ['Appendices', 'Interp']:  # Appendices
-        skip_intros = dropwhile(not_section, nodes)
-        skip_sections = dropwhile(is_section, skip_intros)
-        return list(skip_sections)
+        sections = [sec for sec in nodes if is_app_section(sec)]
+        return sections
     else:   # A Subpart. Most costly as we need to know the toc
         subpart_label = subterp_label[:-1]
         not_subpart = lambda el: el['index'] != subpart_label

--- a/regulations/views/chrome.py
+++ b/regulations/views/chrome.py
@@ -175,8 +175,10 @@ class ChromeSubterpView(ChromeView):
 
         interp = generator.get_tree_paragraph(reg_part + '-Interp', version)
         if not interp:
-            raise error_handling.MissingSectionException(label_id, version,
-                                                         context)
+            interp = generator.get_tree_paragraph(label_id, version)
+            if not interp:
+                raise error_handling.MissingSectionException(label_id, version,
+                                                             context)
 
         subterp_sects = filter_by_subterp(interp['children'], label, version)
         if not subterp_sects:

--- a/regulations/views/partial_interp.py
+++ b/regulations/views/partial_interp.py
@@ -48,7 +48,9 @@ class PartialSubterpView(PartialSectionView):
 
         interp = generator.get_tree_paragraph(reg_part + '-Interp', version)
         if not interp:
-            raise Http404
+            interp = generator.get_tree_paragraph(label_id, version)
+            if not interp:
+                raise Http404
 
         subterp_sects = filter_by_subterp(interp['children'], label, version)
         if not subterp_sects:


### PR DESCRIPTION
This PR provides a fallback for fetching subterps (interpretations to subparts). The problem here is that when regsite gets a request to fetch a subterp, it doesn't just forward that URL to regcore; it actually munges the URL somewhat to infer what the corresponding endpoint in regcore is. I have no idea why they aren't the same, but that's how it is. This causes some real problem when you want to grab something like a subterp for subpart B, let's say, which has label e.g. `1005-Subpart-B-Interp`, but registe is telling regcore to look up `1005-Interp`. Anyway, what this PR does is try the "old" way, but if that fails, try just fetching that label directly, i.e. if fetching a subterp by hitting `1005-Interp` on regcore returns nothing, try getting the original label. 

The other change modifies the way that relevant sections are extracted from the appendix interps.

Testing:

Everything that worked before should continue working as it previously has. This PR is necessary to get the subterps working on the reg E changes, but all tests should pass as before.