### PR TITLE
Properly fix subterp diff URL regex

### DIFF
--- a/regulations/tests/urls_test.py
+++ b/regulations/tests/urls_test.py
@@ -1,5 +1,26 @@
+import re
+
 from unittest import TestCase
 from django.core.urlresolvers import reverse, resolve
+
+from regulations.urls import section_or_subterp_pattern
+
+
+class RegexTests(TestCase):
+    def test_section_or_subterp_matches_section(self):
+        self.assertRegexpMatches('201-2', section_or_subterp_pattern)
+
+    def test_section_or_subterp_matches_subterp_appendices(self):
+        self.assertRegexpMatches(
+            '201-Appendices-Interp',
+            section_or_subterp_pattern
+        )
+
+    def test_section_or_subterp_matches_subterp_subpart(self):
+        self.assertRegexpMatches(
+            '201-Subpart-XY-Interp',
+            section_or_subterp_pattern
+        )
 
 
 class UrlTests(TestCase):
@@ -33,9 +54,3 @@ class UrlTests(TestCase):
             args=('201-2', '2011-1738_20121011', '2012-22345_20131022'))
         self.assertEqual(
             r, '/diff/201-2/2011-1738_20121011/2012-22345_20131022')
-
-    def test_diff_url_supports_multiple_dashes(self):
-        r = reverse(
-            'chrome_section_diff_view',
-            args=('201-Interp-XYZ', '2011-1738', '2012-22345'))
-        self.assertEqual(r, '/diff/201-Interp-XYZ/2011-1738/2012-22345')

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -28,10 +28,19 @@ newer_version_pattern = meta_version % 'newer_version'
 notice_pattern = meta_version % 'notice_id'
 
 reg_pattern = r'(?P<label_id>[\d]+)'
-section_pattern = r'(?P<label_id>[\d]+[-][\w-]+)'
+section_pattern = r'(?P<label_id>[\d]+[-][\w]+)'
 interp_pattern = r'(?P<label_id>[-\d\w]+[-]Interp)'
 paragraph_pattern = r'(?P<label_id>[-\d\w]+)'
 subterp_pattern = r'(?P<label_id>[\d]+-(Appendices|Subpart(-[A-Z]+)?)-Interp)'
+section_or_subterp_pattern = (
+    r'(?P<label_id>'
+    '[\d]+'
+    '('
+    '([-][\w]+)|'
+    '(-(Appendices|Subpart(-[A-Z]+)?)-Interp)'
+    ')'
+    ')'
+)
 
 lt_cache = cache_page(settings.CACHES['eregs_longterm_cache']['TIMEOUT'],
                       cache='eregs_longterm_cache')
@@ -63,7 +72,7 @@ urlpatterns = patterns(
     # Diff view of a section for non-JS viewers (or book markers)
     # Example: http://.../diff/201-4/2011-1738/2013-10704
     url(r'^diff/%s/%s/%s$' %
-        (section_pattern, version_pattern, newer_version_pattern),
+        (section_or_subterp_pattern, version_pattern, newer_version_pattern),
         lt_cache(ChromeSectionDiffView.as_view()),
         name='chrome_section_diff_view'),
     # Redirect to version by date


### PR DESCRIPTION
This change fixes a bug introduced by #836 that incorrectly passed section views to subterp views. It restores the previous section pattern and introduces a new section_or_subterp pattern that's used only for diff URLs.