### PR TITLE
Update functional tests

### DIFF
--- a/regulations/uitests/diff_test.py
+++ b/regulations/uitests/diff_test.py
@@ -2,9 +2,9 @@ import os
 import unittest
 from base_test import BaseTest
 from selenium import webdriver
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.color import Color
+from selenium.webdriver.support.select import Select
+from selenium.webdriver.support.ui import WebDriverWait
 
 class DiffTest(BaseTest, unittest.TestCase):
 
@@ -31,13 +31,13 @@ class DiffTest(BaseTest, unittest.TestCase):
         self.assertTrue('current' in drawer_button.get_attribute('class'))
 
         # drawer should display regulation history
-        timeline_list_items = self.driver.find_elements_by_class_name('history-toc-list')
+        timeline_list_items = self.driver.find_elements_by_css_selector('#history-toc-list .status-list')
         expected_timeline_versions = [
             '2011-11111',
             '2012-12121'
         ]
-        for index, item in enumerate(timeline_list_items):
-            self.assertEqual(item.get_attribute('data-base-version'), expected_timeline_versions[index])
+        for index, expected_version in enumerate(expected_timeline_versions):
+            self.assertEqual(timeline_list_items[index].get_attribute('data-base-version'), expected_version)
 
         # each timeline entry is a link to the rule effective on that date
         timeline_links = self.driver.find_elements_by_class_name('version-link')
@@ -45,8 +45,8 @@ class DiffTest(BaseTest, unittest.TestCase):
             self.test_url + '/1005-2/2011-11111',
             self.test_url + '/1005-2/2012-12121'
         ]
-        for index, link in enumerate(timeline_links):
-            self.assertEqual(link.get_attribute('href'), expected_timeline_urls[index])
+        for index, expected_url in enumerate(expected_timeline_urls):
+            self.assertEqual(timeline_links[index].get_attribute('href'), expected_url)
 
         diff_field = Select(self.driver.find_element_by_xpath('//*[@id="timeline"]/div[2]/ul/li[1]/div/div/div/form/select'))
         # select version to compare to

--- a/regulations/uitests/diff_test.py
+++ b/regulations/uitests/diff_test.py
@@ -4,6 +4,7 @@ from base_test import BaseTest
 from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support.select import Select
+from selenium.webdriver.support.color import Color
 
 class DiffTest(BaseTest, unittest.TestCase):
 
@@ -29,6 +30,24 @@ class DiffTest(BaseTest, unittest.TestCase):
         # drawer button should be active
         self.assertTrue('current' in drawer_button.get_attribute('class'))
 
+        # drawer should display regulation history
+        timeline_list_items = self.driver.find_elements_by_class_name('history-toc-list')
+        expected_timeline_versions = [
+            '2011-11111',
+            '2012-12121'
+        ]
+        for index, item in enumerate(timeline_list_items):
+            self.assertEqual(item.get_attribute('data-base-version'), expected_timeline_versions[index])
+
+        # each timeline entry is a link to the rule effective on that date
+        timeline_links = self.driver.find_elements_by_class_name('version-link')
+        expected_timeline_urls = [
+            self.test_url + '/1005-2/2011-11111',
+            self.test_url + '/1005-2/2012-12121'
+        ]
+        for index, link in enumerate(timeline_links):
+            self.assertEqual(link.get_attribute('href'), expected_timeline_urls[index])
+
         diff_field = Select(self.driver.find_element_by_xpath('//*[@id="timeline"]/div[2]/ul/li[1]/div/div/div/form/select'))
         # select version to compare to
         diff_field.select_by_value('2012-12121')
@@ -50,6 +69,10 @@ class DiffTest(BaseTest, unittest.TestCase):
         WebDriverWait(self.driver, 60).until(
             lambda driver: 'current' in active_drawer_button.get_attribute('class'))
 
+        # diff pane drawer button should be red
+        diff_button_hex_color = Color.from_string(active_drawer_button.value_of_css_property('color')).hex
+        self.assertEqual(diff_button_hex_color, '#d14124')
+
         # navigate to 1005.3
         self.driver.find_element_by_id('menu-link').click()
         WebDriverWait(self.driver, 10).until(
@@ -63,14 +86,24 @@ class DiffTest(BaseTest, unittest.TestCase):
         WebDriverWait(self.driver, 30).until(
             lambda driver: driver.current_url == self.test_url + '/diff/1005-3/2012-12121/2011-11111?from_version=2011-11111')
 
-        # make sure new section is greened
+        # added text should be italicized and highlighted in green
         new_section = self.driver.find_element_by_xpath('//*[@id="1005-3-b-1-vi"]')
-        self.assertTrue(new_section.find_element_by_tag_name('ins'))
+        new_section_insertion = new_section.find_element_by_tag_name('ins')
+        insertion_hex_color = Color.from_string(new_section_insertion.value_of_css_property('background-color')).hex
+        self.assertEqual(new_section_insertion.value_of_css_property('font-style'), 'italic')
+        self.assertEqual(insertion_hex_color, '#e2efd8')
 
         # make sure changed paragraph has insertions and deletions
         changed_section = self.driver.find_element_by_xpath('//*[@id="1005-3-b-2-ii"]')
-        self.assertTrue(len(changed_section.find_elements_by_tag_name('ins')) == 2)
-        self.assertTrue(len(changed_section.find_elements_by_tag_name('del')))
+        changed_section_insertions = changed_section.find_elements_by_tag_name('ins')
+        changed_section_deletion = changed_section.find_elements_by_tag_name('del')
+        self.assertTrue(len(changed_section_insertions) == 2)
+        self.assertTrue(len(changed_section_deletion))
+
+        # deleted text should be struck through and gray
+        deletion_hex_color = Color.from_string(changed_section_deletion[0].value_of_css_property('color')).hex
+        self.assertEqual(deletion_hex_color, '#b4b5b6')
+        self.assertEqual(changed_section_deletion[0].value_of_css_property('text-decoration'), 'line-through')
 
         # go back into diff pane in drawer, stop comparing
         self.get_drawer_button().click()
@@ -80,6 +113,22 @@ class DiffTest(BaseTest, unittest.TestCase):
         # make sure it goes back to the right place
         WebDriverWait(self.driver, 30).until(
             lambda driver: driver.current_url == self.test_url + '/1005-3/2011-11111')
+
+        # "find the regulation effective on this date" takes you to the proper version
+        self.get_drawer_button().click()
+        month_input = self.driver.find_element_by_class_name('month-input')
+        day_input = self.driver.find_element_by_class_name('day-input')
+        year_input = self.driver.find_element_by_class_name('year-input')
+        find_button = self.driver.find_element_by_class_name('find-button')
+        month_input.clear()
+        day_input.clear()
+        year_input.clear()
+        month_input.send_keys('3')
+        day_input.send_keys('10')
+        year_input.send_keys('2012')
+        find_button.click()
+        WebDriverWait(self.driver, 30).until(
+            lambda driver: driver.current_url == self.test_url + '/1005-3/2012-12121')
 
 if __name__ == '__main__':
     unittest.main()

--- a/regulations/uitests/interp_test.py
+++ b/regulations/uitests/interp_test.py
@@ -27,7 +27,7 @@ class InterpTest(BaseTest, unittest.TestCase):
         self.assertTrue('OFFICIAL INTERPRETATION TO 2(h)' in interp_dropdown.text)
 
         # should have the "SHOW" link
-        self.assertTrue('SHOW' in interp_dropdown.text)
+        self.assertIn('SHOW', interp_dropdown.text)
 
         self.driver.execute_script('p10052h = document.getElementById("1005-2-h").offsetTop')
         self.driver.execute_script('window.scrollTo(0, p10052h)')

--- a/regulations/uitests/interp_test.py
+++ b/regulations/uitests/interp_test.py
@@ -26,6 +26,9 @@ class InterpTest(BaseTest, unittest.TestCase):
         # should have the appropriate header
         self.assertTrue('OFFICIAL INTERPRETATION TO 2(h)' in interp_dropdown.text)
 
+        # should have the "SHOW" link
+        self.assertTrue('SHOW' in interp_dropdown.text)
+
         self.driver.execute_script('p10052h = document.getElementById("1005-2-h").offsetTop')
         self.driver.execute_script('window.scrollTo(0, p10052h)')
 
@@ -41,6 +44,11 @@ class InterpTest(BaseTest, unittest.TestCase):
 
         # should contain the appropriate reg section
         self.assertTrue('clicked. A finances centripetally curiousest stronghold cemeteries' in interp_text.text)
+
+        # should contain a link to the appropriate reg section
+        interp_link = self.driver.find_element_by_xpath('//*[@id="1005-2-h"]/section/section/p/a[@class="internal section-link"]')
+        self.assertEqual(self.test_url + '/1005-Subpart-Interp/2012-12121#1005-18-a', interp_link.get_attribute('href'))
+        self.assertEqual(u'See this interpretation in Supplement I', interp_link.text)
 
         self.driver.find_element_by_xpath('//*[@id="1005-2-h"]/section/header/a').click()
 

--- a/regulations/uitests/navigation_test.py
+++ b/regulations/uitests/navigation_test.py
@@ -19,7 +19,7 @@ class NavigationTest(BaseTest, unittest.TestCase):
         self.driver.execute_script('window.scrollTo(0, poffset)')
         # wayfinding header should update
         WebDriverWait(self.driver, 30).until(
-            lambda driver: driver.find_element_by_xpath('//*[@id="active-title"]').text in 
+            lambda driver: driver.find_element_by_xpath('//*[@id="active-title"]').text in
             (u'\u00A71005.5(b)(1)', u'\u00A71005.5(b)'))
 
         fwd_link = self.driver.find_element_by_xpath('//*[@id="1005-5"]/nav/ul/li[2]/a')
@@ -37,6 +37,12 @@ class NavigationTest(BaseTest, unittest.TestCase):
         # should navigate to 1005-4
         WebDriverWait(self.driver, 30).until(
             lambda driver: driver.find_element_by_id('1005-4'))
+
+        # internal reference should link to the correct subsection
+        internal_link_1005_7 = self.driver.find_element_by_xpath('//*[@id="1005-4-d"]//a[@data-section-id="1005-7"]')
+        internal_link_1005_7.click()
+        WebDriverWait(self.driver, 30).until(
+            lambda driver: driver.find_element_by_id('1005-7'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/regulations/uitests/responsive_test.py
+++ b/regulations/uitests/responsive_test.py
@@ -1,0 +1,80 @@
+import os
+import unittest
+from base_test import BaseTest
+from selenium import webdriver
+from selenium.webdriver.support.ui import WebDriverWait
+
+class ResponsiveTest(BaseTest, unittest.TestCase):
+
+    def job_name(self):
+        return 'Responsive test'
+
+    def test_responsive(self):
+        # make window the same size as the viewport of iPhone 6/7/8
+        self.driver.set_window_size(375, 667)
+
+        active_subsection_id = '1005-3-b'
+        self.driver.get(self.test_url + '/1005-3/2012-12121#' + active_subsection_id)
+        html = self.driver.find_element_by_tag_name('html')
+        WebDriverWait(self.driver, 30).until(
+            lambda driver: 'selenium-start' in html.get_attribute('class'))
+
+        # interface is formatted for small screens
+        site_title = self.driver.find_element_by_class_name('site-title')
+        mobile_nav_trigger = self.driver.find_element_by_class_name('mobile-nav-trigger')
+        menu_drawer = self.driver.find_element_by_id('menu')
+        wayfinding_header = self.driver.find_element_by_class_name('wayfinding')
+        sidebar = self.driver.find_element_by_id('sidebar')
+        sample_paragraph = self.driver.find_element_by_xpath('//*[@id="' + active_subsection_id + '"]/p')
+        definition_link = self.driver.find_element_by_xpath('//*[@id="1005-3-a"]/p/a[@class="citation definition"]')
+        window_y_offset = self.driver.execute_script('return window.pageYOffset;')
+        active_subsection_offset = self.driver.execute_script('return document.getElementById("' + active_subsection_id + '").offsetTop;')
+        # site title should be hidden on page load
+        self.assertFalse(site_title.is_displayed())
+        # mobile navigation trigger should be visible on page load
+        self.assertTrue(mobile_nav_trigger.is_displayed())
+        # menu drawer should be closed on page load
+        self.assertIn('close', menu_drawer.get_attribute('class'))
+        # wayfinding header should not be floated
+        self.assertEqual(wayfinding_header.value_of_css_property('float'), 'none')
+        # sidebar shoud not be fixed
+        self.assertNotEqual(sidebar.value_of_css_property('position'), 'fixed')
+        """ active subsection that the URL points to should be at the top of the
+        viewport when the page loads; the window offset minus the subsection
+        offset should be zero, but we use "less than 10" to allow for wiggle
+        room in how different browsers render the page """
+        self.assertTrue(window_y_offset - active_subsection_offset < 10)
+        # wayfinding should update on scroll
+        self.driver.execute_script('window.scrollTo(0, 0);')
+        self.assertEqual(wayfinding_header.text, u'\xa71005.3(a)')
+        # definition panel should be fixed
+        definition_link.click()
+        definition_panel = self.driver.find_element_by_class_name('open-definition')
+        self.assertEqual(definition_panel.value_of_css_property('position'), 'fixed')
+
+        # clicking the ">" icon opens the drawer on top of the main content
+        drawer_toggle = self.driver.find_element_by_id('panel-link')
+        content_body = self.driver.find_element_by_id('content-body')
+        drawer_toggle.click()
+        # menu drawer should open when the draw toggle is clicked
+        self.assertIn('open', menu_drawer.get_attribute('class'))
+        # drawer should open on top of the main content
+        self.assertEqual(content_body.value_of_css_property('margin-left'), '0px')
+
+        # global navigation works on small screens
+        main_navigation = self.driver.find_element_by_class_name('app-nav-list')
+        # main navigation should be hidden on page load
+        self.assertFalse(main_navigation.is_displayed())
+        # main navigation should appear when nav trigger is clicked
+        mobile_nav_trigger.click()
+        self.assertTrue(main_navigation.is_displayed())
+        # landing page should load
+        nav_landing_link = self.driver.find_element_by_link_text('Regulations')
+        nav_landing_link.click()
+        WebDriverWait(self.driver, 30).until(
+            lambda driver: driver.find_element_by_class_name('landing-content'))
+        landing_page_content = self.driver.find_element_by_class_name('landing-content')
+        self.assertTrue(landing_page_content)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/regulations/uitests/search_test.py
+++ b/regulations/uitests/search_test.py
@@ -1,3 +1,8 @@
+""" TODO: Search isn't working correctly when running locally, and any term
+you search for will return 100% of the dummy reg's sections as results. When
+search is working correctly locally, we should update this test to check for
+the correct number and text of results. """
+
 import os
 import unittest
 from base_test import BaseTest
@@ -10,9 +15,7 @@ class SearchTest(BaseTest, unittest.TestCase):
         return 'Search test'
 
     def test_search(self):
-        # make window wide enough so that the left panel defaults to open
-        self.driver.set_window_size(1366, 768)
-
+        self.driver.set_window_size(1024, 600)
         self.driver.get(self.test_url + '/1005')
         html = self.driver.find_element_by_tag_name('html')
         WebDriverWait(self.driver, 30).until(
@@ -33,6 +36,8 @@ class SearchTest(BaseTest, unittest.TestCase):
         search_submit.click()
         WebDriverWait(self.driver, 30).until(
             lambda driver: driver.find_element_by_class_name('result-list'))
+        drawer_toggle = self.driver.find_element_by_id('panel-link')
+        drawer_toggle.click()
         search_header = self.driver.find_element_by_xpath('//h2[@class="search-term"]')
         search_pager = self.driver.find_element_by_class_name('pager')
         search_results = self.driver.find_elements_by_xpath('//ul[@class="result-list"]/li/h3/a')
@@ -54,12 +59,12 @@ class SearchTest(BaseTest, unittest.TestCase):
             self.assertEqual(result.text, expected_results[index])
 
         # clicking a serrch result loads the appropriate subsection
-        search_result_link = search_results[7]
+        search_result_link = search_results[9]
         search_result_link.click()
         WebDriverWait(self.driver, 30).until(
             lambda driver: driver.find_element_by_id('1005-2'))
         wayfinding_header = self.driver.find_element_by_xpath('//*[@id="active-title"]/*[@class="header-label"]')
-        self.assertEqual(wayfinding_header.text, u'\xa71005.2(a)(2)')
+        self.assertEqual(wayfinding_header.text, u'\xa71005.2(a)(2)(i)')
 
 if __name__ == '__main__':
     unittest.main()

--- a/regulations/uitests/search_test.py
+++ b/regulations/uitests/search_test.py
@@ -1,0 +1,65 @@
+import os
+import unittest
+from base_test import BaseTest
+from selenium import webdriver
+from selenium.webdriver.support.ui import WebDriverWait
+
+class SearchTest(BaseTest, unittest.TestCase):
+
+    def job_name(self):
+        return 'Search test'
+
+    def test_search(self):
+        # make window wide enough so that the left panel defaults to open
+        self.driver.set_window_size(1366, 768)
+
+        self.driver.get(self.test_url + '/1005')
+        html = self.driver.find_element_by_tag_name('html')
+        WebDriverWait(self.driver, 30).until(
+            lambda driver: 'selenium-start' in html.get_attribute('class'))
+
+        # clicking on the search icon shows the initially hidden search drawer
+        search_icon = self.driver.find_element_by_id('search-link')
+        search_drawer = self.driver.find_element_by_class_name('search-drawer')
+        self.assertIn('hidden', search_drawer.get_attribute('class'))
+        search_icon.click()
+        self.assertNotIn('hidden', search_drawer.get_attribute('class'))
+
+        # searching for a term displays the correct results
+        search_input = self.driver.find_element_by_id('search-input')
+        search_submit = self.driver.find_element_by_xpath('//*[@id="search"]//button[@type="submit"]')
+        search_term = 'lorem ipsum'
+        search_input.send_keys(search_term)
+        search_submit.click()
+        WebDriverWait(self.driver, 30).until(
+            lambda driver: driver.find_element_by_class_name('result-list'))
+        search_header = self.driver.find_element_by_xpath('//h2[@class="search-term"]')
+        search_pager = self.driver.find_element_by_class_name('pager')
+        search_results = self.driver.find_elements_by_xpath('//ul[@class="result-list"]/li/h3/a')
+        expected_results = [
+            u'1005.Subpart',
+            u'1005.1 \xa7',
+            u'1005.1(a)',
+            u'1005.1(b)',
+            u'1005.2 \xa7',
+            u'1005.2(a)',
+            u'1005.2(a)(1)',
+            u'1005.2(a)(2)',
+            u'1005.2(a)(2)(i)',
+            u'1005.2(a)(2)(ii)'
+        ]
+        self.assertEqual(search_header.text, u'Searching for \u201c' + search_term + u'\u201d')
+        self.assertEqual(search_pager.text, u'Page 1 of 124')
+        for index, result in enumerate(search_results):
+            self.assertEqual(result.text, expected_results[index])
+
+        # clicking a serrch result loads the appropriate subsection
+        search_result_link = search_results[7]
+        search_result_link.click()
+        WebDriverWait(self.driver, 30).until(
+            lambda driver: driver.find_element_by_id('1005-2'))
+        wayfinding_header = self.driver.find_element_by_xpath('//*[@id="active-title"]/*[@class="header-label"]')
+        self.assertEqual(wayfinding_header.text, u'\xa71005.2(a)(2)')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/regulations/uitests/search_test.py
+++ b/regulations/uitests/search_test.py
@@ -55,10 +55,10 @@ class SearchTest(BaseTest, unittest.TestCase):
         ]
         self.assertEqual(search_header.text, u'Searching for \u201c' + search_term + u'\u201d')
         self.assertEqual(search_pager.text, u'Page 1 of 124')
-        for index, result in enumerate(search_results):
-            self.assertEqual(result.text, expected_results[index])
+        for index, expected_result in enumerate(expected_results):
+            self.assertEqual(search_results[index].text, expected_result)
 
-        # clicking a serrch result loads the appropriate subsection
+        # clicking a search result loads the appropriate subsection
         search_result_link = search_results[9]
         search_result_link.click()
         WebDriverWait(self.driver, 30).until(

--- a/regulations/uitests/toc_test.py
+++ b/regulations/uitests/toc_test.py
@@ -30,6 +30,14 @@ class TOCTest(BaseTest, unittest.TestCase):
         # reg section should load in content area
         self.assertTrue('catharine and myriads' in self.driver.find_element_by_class_name('section-title').text)
 
+        # subpart number should display as the active title in the wayfinding subhead
+        active_title_1005_1 = self.driver.find_element_by_id('active-title').text
+        self.assertEqual(active_title_1005_1, u'\xa71005.1')
+
+        # effective date should display in the wayfinding subhead
+        effective_date = self.driver.find_element_by_class_name('effective-date').text
+        self.assertEqual(effective_date, 'Effective Date: 10/28/2012')
+
         # toc link should be highlighted
         self.assertTrue('current' in toc_link_1005_1.get_attribute('class'))
 


### PR DESCRIPTION
Update functional tests to more fully check that the eRegs user interface is working as expected

## Additions

- Added tests for search
- Added tests for responsiveness

## Changes

- Updated tests for diffs
- Updated tests for the table of contents
- Updated tests for navigation
- Updated tests for interpretation

## Testing

1. Break out those terminal tabs!
    1. In one tab, start up `regulations-site` (e.g. `python manage.py runserver 8001`)
    2. In a second tab, go to the root of `regulations-site` and start up the dummy API with `./dummy_api/start.sh 0.0.0.0:8282` (or whatever port you usually run the real API from `regulations-core` on)
    3. In a third tab, start up Sauce Connect however you usually do that
2. Visit `http://localhost:8001/` (or whatever port you're running `regulations-site` on) in a browser; you should see only a single regulation, 1005, on the home screen, and all the content for that regulation should be placeholder gibberish
3. In a fourth terminal tab, go to the root of `regulations-site` and run `grunt test`
4. Waaaaaaaaiiiiiiit for all the functional tests to run in both Chrome and IE on Sauce Labs (it'll take 6–7 minutes for everything to finish)
5. Verify that all the tests pass
6. If you want to, log into Sauce Labs to watch the recordings of the tests to make sure they're doing the right things

## Screenshots

You should see this in your terminal when `grunt test` finishes:

![eregs-terminal](https://user-images.githubusercontent.com/1862695/32850485-4c209176-ca00-11e7-84d9-1df3c9e24ef8.png)

## Notes

- I know almost nothing about Python, yet here you are reviewing a bunch of Python code I wrote 😄 . Definitely let me know if it would make sense to refactor anything (at least I managed not to use any terminal semicolons, I think).

## Todos

- As noted in `search_test.py`, search isn't actually working locally. When you search for **any** term, the app returns every section of the dummy reg as a result. So right now the search test can't fully test searching a reg, but it does check to make sure that all the UI elements used to do a search work. When we get search working locally, it should be pretty easy to update `search_test.py` to account for correct search results. Should we hold off on adding `search_test.py` until then, though?