### PR TITLE
Cap required Django version between 1.8 and 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     setup_requires=['cfgov_setup==1.2', 'setuptools-git-version==1.0.3'],
     frontend_build_script='frontendbuild.sh',
     install_requires=[
-        'django>=1.8',
+        'django>=1.8,<1.12',
         'lxml',
         'requests',
     ],


### PR DESCRIPTION
To avoid issues with incompatibility with Django 2.0.