### PR TITLE
Use self-hosted fonts from cf.gov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ eregsip/
 
 # docs output
 docs/_build
+
+# Static assets #
+#################
+static.in/*/

--- a/README.md
+++ b/README.md
@@ -207,3 +207,16 @@ After you create a [Sauce Labs](https://saucelabs.com) account:
 - Unit tests do not require running the dummy API.
 - To run the unit tests along with the functional tests: ```grunt test``` from the root of the repo.
 - To run unit tests individually: ```grunt mocha_istanbul``` from the root of the repo.
+
+### Font files
+
+The CSS styles for this project refer to some font files which cannot be distributed publicly (see definitions in `regulations/static/regulations/css/less/fonts.less`). These fonts need to live under a `fonts` subdirectory of wherever static assets are served from, e.g. `/static/fonts`. There are fallback fonts defined which will be used if the desired fonts are not available.
+
+If you want to install self-hosted fonts locally for use in development, you can place the font files in `/static.in/cfgov-fonts/fonts/` and restart the local web server. If you are a CFPB employee, you can perform this step with:
+
+```
+cd /static.in/ && git clone https://[GHE]/CFGOV/cfgov-fonts/
+```
+where `[GHE]` is our GitHub Enterprise URL.
+
+See the [cfgov-refresh Webfonts documentation](https://cfpb.github.io/cfgov-refresh/installation/#webfonts) for a similar setup.

--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ After you create a [Sauce Labs](https://saucelabs.com) account:
 
 The CSS styles for this project refer to some font files which cannot be distributed publicly (see definitions in `regulations/static/regulations/css/less/fonts.less`). These fonts need to live under a `fonts` subdirectory of wherever static assets are served from, e.g. `/static/fonts`. There are fallback fonts defined which will be used if the desired fonts are not available.
 
-If you want to install self-hosted fonts locally for use in development, you can place the font files in `/static.in/cfgov-fonts/fonts/` and restart the local web server. If you are a CFPB employee, you can perform this step with:
+If you want to install self-hosted fonts locally for use in development, you can place the font files in repo subdirectory `static.in/cfgov-fonts/fonts/` and restart the local web server. If you are a CFPB employee, you can perform this step with:
 
 ```
-cd /static.in/ && git clone https://[GHE]/CFGOV/cfgov-fonts/
+cd static.in/ && git clone https://[GHE]/CFGOV/cfgov-fonts/
 ```
 where `[GHE]` is our GitHub Enterprise URL.
 

--- a/regulations/settings/dev.py
+++ b/regulations/settings/dev.py
@@ -3,8 +3,12 @@ from .base import *
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
-STATICFILES_DIRS = (
-    root('static'),
+# Add static file directories that live in subdirectories under static.in.
+STATIC_IN = root('static.in')
+STATICFILES_DIRS += tuple(
+    os.path.join(STATIC_IN, d)
+    for d in os.listdir(STATIC_IN)
+    if os.path.isdir(os.path.join(STATIC_IN, d))
 )
 
 

--- a/regulations/static/regulations/css/less/fonts.less
+++ b/regulations/static/regulations/css/less/fonts.less
@@ -6,45 +6,45 @@
 
 @font-face{
     font-family: "Avenir Next";
-    src: url("../../eregsip/font/e9167238-3b3f-4813-a04a-a384394eed42.eot");
-    src: url("../../eregsip/font/e9167238-3b3f-4813-a04a-a384394eed42.eot?iefix") format("embedded-opentype"),
-         url("../../eregsip/font/1e9892c0-6927-4412-9874-1b82801ba47a.woff") format("woff");
+    src: url("../../fonts/e9167238-3b3f-4813-a04a-a384394eed42.eot");
+    src: url("../../fonts/e9167238-3b3f-4813-a04a-a384394eed42.eot?iefix") format("embedded-opentype"),
+         url("../../fonts/1e9892c0-6927-4412-9874-1b82801ba47a.woff") format("woff");
     font-weight: 400;
     font-style: normal;
 }
 
 @font-face{
     font-family: "Avenir Next Italic";
-    src: url("../../eregsip/font/d1fddef1-d940-4904-8f6c-17e809462301.eot");
-    src: url("../../eregsip/font/d1fddef1-d940-4904-8f6c-17e809462301.eot?iefix") format("embedded-opentype"),
-         url("../../eregsip/font/92b66dbd-4201-4ac2-a605-4d4ffc8705cc.woff") format("woff");
+    src: url("../../fonts/d1fddef1-d940-4904-8f6c-17e809462301.eot");
+    src: url("../../fonts/d1fddef1-d940-4904-8f6c-17e809462301.eot?iefix") format("embedded-opentype"),
+         url("../../fonts/92b66dbd-4201-4ac2-a605-4d4ffc8705cc.woff") format("woff");
     font-weight: 400;
     font-style: italic;
 }
 
 @font-face{
     font-family: "Avenir Next Demi";
-    src: url("../../eregsip/font/12d643f2-3899-49d5-a85b-ff430f5fad15.eot");
-    src: url("../../eregsip/font/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?iefix") format("embedded-opentype"),
-         url("../../eregsip/font/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff") format("woff");
+    src: url("../../fonts/12d643f2-3899-49d5-a85b-ff430f5fad15.eot");
+    src: url("../../fonts/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?iefix") format("embedded-opentype"),
+         url("../../fonts/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff") format("woff");
     font-weight: 600;
     font-style: normal;
 }
 
 @font-face{
     font-family: "Avenir Next Bold";
-    src: url("../../eregsip/font/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot");
-    src: url("../../eregsip/font/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot?iefix") format("embedded-opentype"),
-         url("../../eregsip/font/b8e906a1-f5e8-4bf1-8e80-82c646ca4d5f.woff") format("woff");
+    src: url("../../fonts/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot");
+    src: url("../../fonts/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot?iefix") format("embedded-opentype"),
+         url("../../fonts/b8e906a1-f5e8-4bf1-8e80-82c646ca4d5f.woff") format("woff");
     font-weight: 700;
     font-style: normal;
 }
 
 @font-face{
     font-family: "Avenir Next Demi Italic";
-    src: url("../../eregsip/font/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot");
-    src: url("../../eregsip/font/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot?#iefix") format("embedded-opentype"),
-         url("../../eregsip/font/bc350df4-3100-4ce1-84ce-4a5363dbccfa.woff") format("woff");
+    src: url("../../fonts/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot");
+    src: url("../../fonts/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot?#iefix") format("embedded-opentype"),
+         url("../../fonts/bc350df4-3100-4ce1-84ce-4a5363dbccfa.woff") format("woff");
     font-weight: 600;
     font-style: italic;
 }

--- a/regulations/static/regulations/css/less/fonts.less
+++ b/regulations/static/regulations/css/less/fonts.less
@@ -6,8 +6,7 @@
 
 @font-face{
     font-family: "Avenir Next";
-    src: url("../../fonts/e9167238-3b3f-4813-a04a-a384394eed42.eot");
-    src: url("../../fonts/e9167238-3b3f-4813-a04a-a384394eed42.eot?iefix") format("embedded-opentype"),
+    src: url("../../fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2") format("woff2"),
          url("../../fonts/1e9892c0-6927-4412-9874-1b82801ba47a.woff") format("woff");
     font-weight: 400;
     font-style: normal;
@@ -15,8 +14,7 @@
 
 @font-face{
     font-family: "Avenir Next Italic";
-    src: url("../../fonts/d1fddef1-d940-4904-8f6c-17e809462301.eot");
-    src: url("../../fonts/d1fddef1-d940-4904-8f6c-17e809462301.eot?iefix") format("embedded-opentype"),
+    src: url("../../fonts/7377dbe6-f11a-4a05-b33c-bc8ce1f60f84.woff2") format("woff2"),
          url("../../fonts/92b66dbd-4201-4ac2-a605-4d4ffc8705cc.woff") format("woff");
     font-weight: 400;
     font-style: italic;
@@ -24,8 +22,7 @@
 
 @font-face{
     font-family: "Avenir Next Demi";
-    src: url("../../fonts/12d643f2-3899-49d5-a85b-ff430f5fad15.eot");
-    src: url("../../fonts/12d643f2-3899-49d5-a85b-ff430f5fad15.eot?iefix") format("embedded-opentype"),
+    src: url("../../fonts/aad99a1f-7917-4dd6-bbb5-b07cedbff64f.woff2") format("woff2"),
          url("../../fonts/91b50bbb-9aa1-4d54-9159-ec6f19d14a7c.woff") format("woff");
     font-weight: 600;
     font-style: normal;
@@ -33,8 +30,7 @@
 
 @font-face{
     font-family: "Avenir Next Bold";
-    src: url("../../fonts/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot");
-    src: url("../../fonts/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot?iefix") format("embedded-opentype"),
+    src: url("../../fonts/14c73713-e4df-4dba-933b-057feeac8dd1.woff2") format("woff2"),
          url("../../fonts/b8e906a1-f5e8-4bf1-8e80-82c646ca4d5f.woff") format("woff");
     font-weight: 700;
     font-style: normal;
@@ -42,8 +38,7 @@
 
 @font-face{
     font-family: "Avenir Next Demi Italic";
-    src: url("../../fonts/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot");
-    src: url("../../fonts/770d9a7e-8842-4376-9319-8f2c8b8e880d.eot?#iefix") format("embedded-opentype"),
+    src: url("../../fonts/687932cb-145b-4690-a21d-ed1243db9e36.woff2") format("woff2"),
          url("../../fonts/bc350df4-3100-4ce1-84ce-4a5363dbccfa.woff") format("woff");
     font-weight: 600;
     font-style: italic;


### PR DESCRIPTION
This commit deprecates use of the font files in the private "eregsip" repository, instead using font files located at `/static/fonts` that are provided by cf.gov. Additionally, the ability to add these fonts locally is provided via a new `static.in` directory, akin to how cfgov-refresh does it. See documentation here:

https://cfpb.github.io/cfgov-refresh/installation/#webfonts

I've updated the README to make a note of this.