### PR TITLE
Toggle reg update messages via settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,16 @@ cd static.in/ && git clone https://[GHE]/CFGOV/cfgov-fonts/
 where `[GHE]` is our GitHub Enterprise URL.
 
 See the [cfgov-refresh Webfonts documentation](https://cfpb.github.io/cfgov-refresh/installation/#webfonts) for a similar setup.
+
+## Configuration
+
+### Update notices
+
+Define an `EREGS_REGULATION_UPDATES` Django setting in order to temporarily place a notice on the landing page of regulations that are in the process of being updated. For example, to turn on this notice for regulations for part 1003 and part 1005, define:
+
+```py
+# in your Django settings file
+EREGS_REGULATION_UPDATES = ['1003', '1005']
+```
+
+Content for this notice can be found in `regulations/templates/regulations/generic_landing.html`.

--- a/regulations/static/regulations/css/less/module/reg-landing.less
+++ b/regulations/static/regulations/css/less/module/reg-landing.less
@@ -157,6 +157,12 @@ Main Content Area
     padding: 10px;
 }
 
+.alert_section + .alert_section {
+    padding-top: 10px;
+    border-top: 1px solid @gray-40;
+    margin-top: 10px;
+}
+
 @media only screen and ( min-width: 1000px ) {
   .alert_effective-date {
       float: left;

--- a/regulations/templates/regulations/generic_landing.html
+++ b/regulations/templates/regulations/generic_landing.html
@@ -19,7 +19,7 @@
 
             {% update_in_progress reg_part as reg_update_in_progress %}
             {% if reg_update_in_progress %}
-            <div class="group">
+            <div class="group important">
               <p>
                 We’re working on adding recently released updates to this regulation. In the meantime, you can see
                 <a href="https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/"

--- a/regulations/templates/regulations/generic_landing.html
+++ b/regulations/templates/regulations/generic_landing.html
@@ -22,8 +22,7 @@
             <div class="group important">
               <p>
                 We’re working on adding recently released updates to this regulation. In the meantime, you can see
-                <a href="https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/"
-                  >all the final rules issued by the CFPB</a>.
+                <a href="https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/" class="standard">all the final rules issued by the CFPB</a>.
               </p>
             </div>
             {% endif %}

--- a/regulations/templates/regulations/generic_landing.html
+++ b/regulations/templates/regulations/generic_landing.html
@@ -6,25 +6,32 @@
             {% block reg_title %}
             {% endblock %}
 
-            {% if new_version %}
-            <div class="alert effective-alert group">
-              <div class="alert_effective-date">
-                  New amendments effective: <strong>{{new_version.by_date|date:"m/d/Y"}}</strong>
-              </div>
-              <div class="alert_view-link">
-                  <a href="{% url 'chrome_section_view' reg_first_section new_version.version %}" class="go">View amended regulation</a></li>
-              </div>
-            </div><!--/.alert-->
-            {% endif %}
-
             {% update_in_progress reg_part as reg_update_in_progress %}
-            {% if reg_update_in_progress %}
-            <div class="group important">
-              <p>
-                We’re working on adding recently released updates to this regulation. In the meantime, you can see
-                <a href="https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/" class="standard">all the final rules issued by the CFPB</a>.
-              </p>
-            </div>
+            {% if new_version or reg_update_in_progress %}
+                <div class="alert effective-alert group">
+                    {% if new_version %}
+                        <div class="alert_section group">
+                            <div class="alert_effective-date">
+                                New amendments effective: <strong>{{new_version.by_date|date:"m/d/Y"}}</strong>
+                            </div>
+                            <div class="alert_view-link">
+                                <a href="{% url 'chrome_section_view' reg_first_section new_version.version %}" class="go">
+                                    View amended regulation
+                                </a>
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if reg_update_in_progress %}
+                        <div class="alert_section group">
+                            <strong>
+                                We’re working on incorporating amendments to this regulation.
+                            </strong>
+                            In the meantime, please review
+                            <a href="https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/" class="standard">
+                                CFPB rules recently published in the Federal Register</a>.
+                        </div>
+                    {% endif %}
+                </div><!--/.alert-->
             {% endif %}
 
             {% block reg_main_content %}

--- a/regulations/templates/regulations/generic_landing.html
+++ b/regulations/templates/regulations/generic_landing.html
@@ -1,3 +1,5 @@
+{% load reg_updates %}
+
 <div id="content-body" class="main-content">
     <section id="content-wrapper">
         <section data-base-version="{{ current_version.version }}" class="landing" data-page-type="landing-page" data-reg-part="{{reg_part}}">
@@ -13,6 +15,17 @@
                   <a href="{% url 'chrome_section_view' reg_first_section new_version.version %}" class="go">View amended regulation</a></li>
               </div>
             </div><!--/.alert-->
+            {% endif %}
+
+            {% update_in_progress reg_part as reg_update_in_progress %}
+            {% if reg_update_in_progress %}
+            <div class="group">
+              <p>
+                We’re working on adding recently released updates to this regulation. In the meantime, you can see
+                <a href="https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/"
+                  >all the final rules issued by the CFPB</a>.
+              </p>
+            </div>
             {% endif %}
 
             {% block reg_main_content %}

--- a/regulations/templates/regulations/specific/landing_1026.html
+++ b/regulations/templates/regulations/specific/landing_1026.html
@@ -7,11 +7,6 @@
 
 {% block reg_main_content %}
 <div class="group">
-
-    <div class="group important">
-        <p>The Bureau is currently updating the tool to reflect recent changes.</p>
-    </div>
-
 <div class="reg-tags">
         <h3 class="list-header">Consumer credit includes: </h3>
         <ul class="tag-list">

--- a/regulations/templatetags/reg_updates.py
+++ b/regulations/templatetags/reg_updates.py
@@ -1,0 +1,24 @@
+from django import template
+from django.conf import settings
+
+
+register = template.Library()
+
+
+@register.assignment_tag
+def update_in_progress(reg_part):
+    """Given a regulation, is there an update currently in progress?
+
+    This template tag checks for a list in the Django setting
+    EREGS_REGULATION_UPDATES, and, if that setting exists, checks if the given
+    regulation part is in that list.
+
+    Use it in a template like:
+
+        {% update_in_progress reg_part as reg_update_in_progress %}
+        {% if reg_update_in_progress %}
+        <p>An update is in progress to this regulation.</p>
+        {% endif %}
+    """
+    regulation_updates = getattr(settings, 'EREGS_REGULATION_UPDATES', [])
+    return reg_part in regulation_updates

--- a/regulations/tests/templatetags_reg_updates_tests.py
+++ b/regulations/tests/templatetags_reg_updates_tests.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.template import Context, Template
+from django.test import SimpleTestCase, override_settings
+
+
+class RegUpdatesTemplateTagsTestCase(SimpleTestCase):
+    def render(self, reg_part):
+        template = Template(
+            "{% load reg_updates %}"
+            "{% update_in_progress reg_part as reg_update %}"
+            "{{ reg_update }}"
+        )
+        context = Context({'reg_part': reg_part})
+        return template.render(context)
+
+    @override_settings()
+    def test_no_setting_reg_not_being_updated_returns_false(self):
+        del settings.EREGS_REGULATION_UPDATES
+        self.assertEqual(self.render('1099'), 'False')
+
+    @override_settings(EREGS_REGULATION_UPDATES=['1098', '1099'])
+    def test_setting_includes_reg_returns_true(self):
+        self.assertEqual(self.render('1099'), 'True')
+
+    @override_settings(EREGS_REGULATION_UPDATES=['1001', '1002'])
+    def test_setting_doesnt_include_reg_returns_false(self):
+        self.assertEqual(self.render('1099'), 'False')


### PR DESCRIPTION
This commit adds support for a new Django setting, `EREGS_REGULATION_UPDATES`, that allows for placement of a message on certain regulations to let users know that an update in progress. This allows for a central place to toggle these updates instead of requiring
changes on each reg's specific landing page.

Implementation is done via a new `{% update_in_progress %}` template tag that can be passed a regulation part, that checks the hardcoded list in settings.

This change also removes the hardcoded update message that currently appears on part 1026 (Reg Z) and so any deployments will need to add the setting like this to maintain current behavior:

```py
# in Django settings file
EREGS_REGULATION_UPDATES = ['1026']
```

Documentation has been updated in the `README.md` file and new unit tests have been added.

I'm assigning this PR to @niqjohnson pending his revisions on the design of the message, please feel free to push any desired changes to this branch.