### PR TITLE
Add tox for running unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ docs/_build
 # Static assets #
 #################
 static.in/*/
+
+# Unit test / coverage reports #
+################################
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,14 @@ sudo: false
 python:
 - '2.7'
 nodejs: 6
-env:
-  global:
-  - secure: KUZAbAiGyBfiCePYo0MJVpu4YgWvYsPVxrhMOmN3vyEP2O1PpMcFJR/ESyK9mDCJ4Xck5Fc3sDfjRCDW2N6AdVPe313ERIAUxHEw9wFoeRuYl/0B/31KMSO/IjHmHwc1wW2vgtlLP/P3pa3vwr1jsJAhcrF3FBw0EnW5sz7OZQY=
-  - secure: SOpgDODtfEwNPWssGj5CQfQKBFxbJ1w3HZGbG/B9iMS4DtMz/8pBY9G4uzF0KLpNfsllzjOSlMmTFn0tQIE2QR+ifkuIBl+ksvC2/ZagNNRVg7mSe427WeGY4SnH1tvBbarFbJYlFgGjnRJylwyUar7RGqEQ4My2e6/PHreGx6I=
-before_script:
-- if [ "$TRAVIS_PULL_REQUEST" == false ] && [ "$SAUCE_USERNAME" ] && [ "$SAUCE_ACCESS_KEY"
-  ]; then SAUCE_OK=1; else SAUCE_OK=0; fi
-- function START_SAUCE_CONNECT { curl -L https://gist.githubusercontent.com/santiycr/5139565/raw/sauce_connect_setup.sh
-  | bash & }
-- if [ "$SAUCE_OK" == 1 ]; then START_SAUCE_CONNECT; fi;
 before_install:
 - npm install -g grunt-cli
 install:
-- pip install -r requirements.txt
-- pip install -r requirements_test.txt
+- pip install tox
 - ./frontendbuild.sh
 script:
-- python manage.py test
-- ./dummy_api/start.sh
-- echo 'API_BASE = "http://localhost:8282/"' >> regulations/settings/local_settings.py
-- ./run_server.sh &
-- sleep 5
-- if [ "$SAUCE_OK" == 1 ]; then grunt nose; fi
-- python setup.py bdist_wheel
+- tox
+- python2.7 setup.py bdist_wheel
 deploy:
   provider: releases
   skip_cleanup: true

--- a/regulations/tests/external_citations_tests.py
+++ b/regulations/tests/external_citations_tests.py
@@ -18,7 +18,7 @@ class ExternalCitationsTest(TestCase):
         citation = [111, 203]
         ExternalCitationLayer.generate_public_law_link(text, citation)
         parameters = generate_fdsys_href_tag.call_args[0][1]
-        self.assertEqual(parameters.keys(), ['collection', 'lawnum', 'congress', 'lawtype'])
+        self.assertItemsEqual(parameters.keys(), ['collection', 'lawnum', 'congress', 'lawtype'])
         self.assertEqual(parameters['collection'], 'plaw')
         self.assertEqual(parameters['congress'], 111)
         self.assertEqual(parameters['lawnum'], 203)
@@ -30,7 +30,7 @@ class ExternalCitationsTest(TestCase):
         citation = [12, 200]
         ExternalCitationLayer.generate_cfr_link(text, citation)
         parameters = generate_fdsys_href_tag.call_args[0][1]
-        self.assertEqual(parameters.keys(), ['titlenum', 'link-type', 'collection', 'partnum'])
+        self.assertItemsEqual(parameters.keys(), ['titlenum', 'link-type', 'collection', 'partnum'])
         self.assertEqual(parameters['titlenum'], 12)
         self.assertEqual(parameters['link-type'], 'xml')
         self.assertEqual(parameters['collection'], 'cfr')

--- a/regulations/tests/tree_builder_tests.py
+++ b/regulations/tests/tree_builder_tests.py
@@ -40,7 +40,7 @@ class TreeBuilderTest(TestCase):
     def test_parent_in_tree(self):
         tree = self.build_tree()
         tree_hash = tree_builder.build_tree_hash(tree)
-        self.assertEqual(tree_hash.keys(), ['204-3', '204'])
+        self.assertItemsEqual(tree_hash.keys(), ['204-3', '204'])
 
         self.assertTrue(tree_builder.parent_in_tree('204-3', tree_hash))
 
@@ -54,7 +54,7 @@ class TreeBuilderTest(TestCase):
         }
         tree = self.build_tree()
         tree_hash = tree_builder.build_tree_hash(tree)
-        self.assertEqual(tree_hash.keys(), ['204-3', '204'])
+        self.assertItemsEqual(tree_hash.keys(), ['204-3', '204'])
 
         self.assertEqual(len(tree_hash['204']['children']), 1)
         tree_builder.add_node_to_tree(new_node, '204', tree_hash)

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,36 @@
-import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 setup(
     name="regulations",
     version_format='{tag}.dev{commitcount}+{gitsha}',
-    packages=find_packages(),
+    packages=['regulations'],
     include_package_data=True,
-    setup_requires=['cfgov_setup==1.2', 'setuptools-git-version==1.0.3'],
+    setup_requires=[
+        'cfgov_setup==1.2',
+        'setuptools-git-version==1.0.3',
+    ],
     frontend_build_script='frontendbuild.sh',
     install_requires=[
-        'django>=1.8,<1.12',
-        'lxml',
-        'requests',
+        'Django>=1.8,<1.9',
+        'lxml==4.1.0',
+        'requests==2.12.4',
     ],
     classifiers=[
+        'Framework :: Django',
+        'Framework :: Django :: 1.8',
         'License :: Public Domain',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication'
-    ]
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+    ],
+    extras_require={
+        'testing': [
+            'coverage>=3.7.0',
+            'django-nose==1.4.5',
+            'mock==2.0.0',
+            'nose-exclude==0.5.0',
+        ],
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+skipsdist=True
+envlist=py{27}-dj{18}
+
+[testenv]
+install_command=pip install -e ".[testing]" -U {opts} {packages}
+commands=coverage run {toxinidir}/manage.py test --noinput
+
+basepython=
+    py27: python2.7
+
+deps=
+    dj18: Django>=1.8,<1.9


### PR DESCRIPTION
This change adds support for tox (http://tox.readthedocs.io/) for running Python unit tests in a parameterized way.

Python unit tests can be run from the command line using `tox`. For now there is only a single environment (Python 2.7 and Django 1.8), but this change will make it easier to add testing against other Python/Django versions in future.

Some minor changes/fixes were made to a few unit tests to make this work properly, specifically some tests were assuming an order for dictionary keys, which is not dependable.

This change also modifies how TravisCI runs the unit tests so that it invokes tox instead of running the test command directly.

It also removes the invocation of browser tests from Travis (using Sauce Labs) as these have been failing for quite some time.