### PR TITLE
Use nvm explicitly to enforce npm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
 - '2.7'
-nodejs: 6
 env:
   global:
   - secure: KUZAbAiGyBfiCePYo0MJVpu4YgWvYsPVxrhMOmN3vyEP2O1PpMcFJR/ESyK9mDCJ4Xck5Fc3sDfjRCDW2N6AdVPe313ERIAUxHEw9wFoeRuYl/0B/31KMSO/IjHmHwc1wW2vgtlLP/P3pa3vwr1jsJAhcrF3FBw0EnW5sz7OZQY=
@@ -14,6 +13,7 @@ before_script:
   | bash & }
 - if [ "$SAUCE_OK" == 1 ]; then START_SAUCE_CONNECT; fi;
 before_install:
+- nvm use 6
 - npm install -g grunt-cli
 install:
 - pip install -r requirements.txt


### PR DESCRIPTION
This change modifies how the Node version is specified in the Travis CI build. The `"nodejs: 6"` entry in `.travis.yml` wasn't properly setting the Node version to the desired 6.x version. This was causing problems because Travis was using Node 8.x, which modified the `npm-shrinkwrap.json` file. This in turn created a "dirty" git state which caused release wheels to be named improperly.

Ping @higs4281 who I know was experiencing something similar in another repository.

This repository should probably be upgraded to explicitly use Node 8 instead of Node 6, but that is left for a future effort.