### PR TITLE
Fix missing package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 setup(
     name="regulations",
     version_format='{tag}.dev{commitcount}+{gitsha}',
-    packages=['regulations'],
+    packages=find_packages(),
     include_package_data=True,
     setup_requires=[
         'cfgov_setup==1.2',


### PR DESCRIPTION
PR #844 (1ca46ca026631282d7e735e173fbf48976cbab77) broke packaging of this project by omitting subdirectories of the `regulations` app. This change reverts the change to setup.py and ensures that all code is packaged properly.