### PR TITLE
Add update-in-progress alert to sidebar of all regulation pages

### DIFF
--- a/regulations/static/regulations/css/less/module/sidebar.less
+++ b/regulations/static/regulations/css/less/module/sidebar.less
@@ -435,6 +435,26 @@ Styles for the UI help slide down
 }
 
 /*
+Sidebar alert
+===============
+The alert that appears in the sidebar of any reg we're working on updating
+*/
+
+.sidebar-inner {
+    .alert {
+        border-top: none;
+        border-right: none;
+        border-bottom: 1px solid @gray-20;
+        border-left: none;
+    }
+
+    .effective-alert {
+        padding-left: 12px;
+        padding-right: 25px;
+    }
+}
+
+/*
 Small screens
 ---------------
 */
@@ -476,6 +496,13 @@ Small screens
 
     #sxs-list {
         border-top: 1px solid @neutral-40;
+    }
+
+    .sidebar-inner {
+        .alert {
+            border-top: 1px solid @gray-20;
+            border-bottom: none;
+        }
     }
 
     /*
@@ -529,6 +556,14 @@ Small screens
             a {
                 margin-right: 10px;
             }
+        }
+    }
+
+    /* Match sidebar alert margins to the expandables */
+    .sidebar-inner {
+        .effective-alert {
+            padding-left: 10px;
+            padding-right: 10px;
         }
     }
 }

--- a/regulations/static/regulations/css/less/module/sxs.less
+++ b/regulations/static/regulations/css/less/module/sxs.less
@@ -165,6 +165,14 @@ Metadata info for the SxS Analysis
         font-size: 14px;
         text-transform: none;
     }
+
+    .alert {
+        margin-top: 14px;
+
+        & + h3 {
+            margin-top: 30px;
+        }
+    }
 }
 
 .further-analysis {

--- a/regulations/static/regulations/js/source/views/sidebar/alert-view.js
+++ b/regulations/static/regulations/js/source/views/sidebar/alert-view.js
@@ -1,0 +1,11 @@
+'use strict';
+var $ = require( 'jquery' );
+var _ = require( 'underscore' );
+var Backbone = require( 'backbone' );
+Backbone.$ = $;
+
+var AlertView = Backbone.View.extend( {
+  el: '#update-alert'
+} );
+
+module.exports = AlertView;

--- a/regulations/static/regulations/js/source/views/sidebar/sidebar-view.js
+++ b/regulations/static/regulations/js/source/views/sidebar/sidebar-view.js
@@ -5,6 +5,7 @@ var Backbone = require( 'backbone' );
 var RegModel = require( '../../models/reg-model' );
 var SxSList = require( './sxs-list-view' );
 var HelpView = require( './help-view' );
+var AlertView = require( './alert-view' );
 var SidebarModel = require( '../../models/sidebar-model' );
 var DefinitionModel = require( '../../models/definition-model' );
 var Breakaway = require( '../breakaway/breakaway-view' );
@@ -115,6 +116,7 @@ var SidebarView = Backbone.View.extend( {
     // new views to bind to new html
     this.childViews.sxs = new SxSList();
     this.childViews.help = new HelpView();
+    this.childViews.alert = new AlertView();
 
     this.loaded();
   },
@@ -124,6 +126,10 @@ var SidebarView = Backbone.View.extend( {
   },
 
   createPlaceholders: function() {
+    if ( this.$el.find( '#update-alert' ).length === 0 ) {
+      this.$el.append( '<section id="update-alert" class="regs-meta"></section>' );
+    }
+
     if ( this.$el.find( '#sxs-list' ).length === 0 ) {
       this.$el.append( '<section id="sxs-list" class="regs-meta"></section>' );
     }

--- a/regulations/static/regulations/js/unittests/specs/views/sidebar/alert-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/sidebar/alert-view-spec.js
@@ -1,0 +1,22 @@
+require('../../../setup');
+var sinon = require( 'sinon' );
+
+describe('Alert View:', function() {
+
+  var view, definition, $, AlertView;
+
+  before(function() {
+    $ = require('jquery');
+    AlertView = require('../../../../source/views/sidebar/alert-view');
+  });
+
+  beforeEach(function(){
+    // create a new instance of the view
+    view = new AlertView();
+  });
+
+  it('should construct a view', function() {
+    expect(view).to.be.defined;
+  });
+
+});

--- a/regulations/templates/regulations/chrome-empty-sidebar.html
+++ b/regulations/templates/regulations/chrome-empty-sidebar.html
@@ -1,5 +1,6 @@
 {% extends "regulations/chrome.html" %}
 {% load static from staticfiles %}
+{% load reg_updates %}
 
 {% comment %}
 Search results (and perhaps other pages) need a sidebar containing only help text
@@ -7,8 +8,17 @@ Search results (and perhaps other pages) need a sidebar containing only help tex
 
 {% block reg_sidebar %}
 
+{% update_in_progress label_id as reg_update_in_progress %}
+{% if reg_update_in_progress %}
+<section id="update-alert" class="regs-meta">
+    <div class="alert effective-alert group">
+        {% include "regulations/update-alert.html" %}
+    </div>
+</section>
+{% endif %}
+
 <section id="help" class="regs-meta">
-    {% include "regulations/generic_help.html" %} 
+    {% include "regulations/generic_help.html" %}
 
         {% comment %}
         The help-subsection block is used to offer contextual content in different

--- a/regulations/templates/regulations/generic_landing.html
+++ b/regulations/templates/regulations/generic_landing.html
@@ -22,14 +22,7 @@
                         </div>
                     {% endif %}
                     {% if reg_update_in_progress %}
-                        <div class="alert_section group">
-                            <strong>
-                                We’re working on incorporating amendments to this regulation.
-                            </strong>
-                            In the meantime, please review
-                            <a href="https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/" class="standard">
-                                CFPB rules recently published in the Federal Register</a>.
-                        </div>
+                        {% include "regulations/update-alert.html" %}
                     {% endif %}
                 </div><!--/.alert-->
             {% endif %}

--- a/regulations/templates/regulations/generic_landing.html
+++ b/regulations/templates/regulations/generic_landing.html
@@ -6,7 +6,7 @@
             {% block reg_title %}
             {% endblock %}
 
-            {% update_in_progress reg_part as reg_update_in_progress %}
+            {% update_in_progress label_id as reg_update_in_progress %}
             {% if new_version or reg_update_in_progress %}
                 <div class="alert effective-alert group">
                     {% if new_version %}

--- a/regulations/templates/regulations/paragraph-sxs.html
+++ b/regulations/templates/regulations/paragraph-sxs.html
@@ -1,3 +1,5 @@
+{% load reg_updates %}
+
 {% if sxs.label %}
     <div class="sxs-header">
         <a class="sxs-back-button" href="{{ back_url }}"><span class="cf-icon cf-icon-arrow-left-round"></span> {{sxs.header}}</a>
@@ -41,6 +43,13 @@
 
 {% if sxs.label %}
 <div id="metadata-{{sxs.label}}" class="sxs-metadata">
+
+    {% update_in_progress label_id as reg_update_in_progress %}
+    {% if reg_update_in_progress %}
+    <div class="alert effective-alert group">
+        {% include "regulations/update-alert.html" %}
+    </div>
+    {% endif %}
 
     <h3>ANALYSIS TAKEN FROM:</h3>
 

--- a/regulations/templates/regulations/sidebar.html
+++ b/regulations/templates/regulations/sidebar.html
@@ -1,4 +1,14 @@
 {% load static from staticfiles %}
+{% load reg_updates %}
+
+{% update_in_progress label_id as reg_update_in_progress %}
+{% if reg_update_in_progress %}
+<section id="update-alert" class="regs-meta">
+    <div class="alert effective-alert group">
+        {% include "regulations/update-alert.html" %}
+    </div>
+</section>
+{% endif %}
 
 <section id="sxs-list" class="regs-meta">
     <header id="sxs-expandable-header" class="expandable sxs-expand group" data-expandable="sxs-expandable">

--- a/regulations/templates/regulations/update-alert.html
+++ b/regulations/templates/regulations/update-alert.html
@@ -1,0 +1,12 @@
+{% comment %}
+    The alert displayed on all pages of a regulation while updates are in progress.
+{% endcomment %}
+
+<div class="alert_section group">
+    <strong>
+        We’re working on incorporating amendments to this regulation.
+    </strong>
+    In the meantime, please review
+    <a href="https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/" class="standard">
+        CFPB rules recently published in the Federal Register</a>.
+</div>

--- a/regulations/templatetags/reg_updates.py
+++ b/regulations/templatetags/reg_updates.py
@@ -6,7 +6,7 @@ register = template.Library()
 
 
 @register.assignment_tag
-def update_in_progress(reg_part):
+def update_in_progress(label_id):
     """Given a regulation, is there an update currently in progress?
 
     This template tag checks for a list in the Django setting
@@ -15,10 +15,11 @@ def update_in_progress(reg_part):
 
     Use it in a template like:
 
-        {% update_in_progress reg_part as reg_update_in_progress %}
+        {% update_in_progress label_id as reg_update_in_progress %}
         {% if reg_update_in_progress %}
         <p>An update is in progress to this regulation.</p>
         {% endif %}
     """
     regulation_updates = getattr(settings, 'EREGS_REGULATION_UPDATES', [])
+    reg_part = label_id.split('-')[0]
     return reg_part in regulation_updates

--- a/regulations/tests/templatetags_reg_updates_tests.py
+++ b/regulations/tests/templatetags_reg_updates_tests.py
@@ -4,24 +4,24 @@ from django.test import SimpleTestCase, override_settings
 
 
 class RegUpdatesTemplateTagsTestCase(SimpleTestCase):
-    def render(self, reg_part):
+    def render(self, label_id):
         template = Template(
             "{% load reg_updates %}"
-            "{% update_in_progress reg_part as reg_update %}"
+            "{% update_in_progress label_id as reg_update %}"
             "{{ reg_update }}"
         )
-        context = Context({'reg_part': reg_part})
+        context = Context({'label_id': label_id})
         return template.render(context)
 
     @override_settings()
     def test_no_setting_reg_not_being_updated_returns_false(self):
         del settings.EREGS_REGULATION_UPDATES
-        self.assertEqual(self.render('1099'), 'False')
+        self.assertEqual(self.render('1099-1'), 'False')
 
     @override_settings(EREGS_REGULATION_UPDATES=['1098', '1099'])
     def test_setting_includes_reg_returns_true(self):
-        self.assertEqual(self.render('1099'), 'True')
+        self.assertEqual(self.render('1099-1'), 'True')
 
     @override_settings(EREGS_REGULATION_UPDATES=['1001', '1002'])
     def test_setting_doesnt_include_reg_returns_false(self):
-        self.assertEqual(self.render('1099'), 'False')
+        self.assertEqual(self.render('1099-1'), 'False')


### PR DESCRIPTION
Show the update-in-progress alert from #843 in the sidebar of *all* pages of an affected regulation instead of just the landing page.

## Additions

- Add new alert-in-a-sidebar styles
- Add new alert-in-a-sidebar Backbone view (and test)

## Changes

- Pull the text of the update-in-progress alert into its own template since it's now reused across many page types
- Use `label_id` instead of `reg_part` in the `reg_updates.py` template tag (`label_id` is available in every template, `reg_part` isn't)
- Add the update-in-progress alert to all the relevant sidebar templates

## Testing

1. Rebuild the frontend assets from this branch with `./frontendbuild.sh`
2. Start eRegs locally from this branch (`EREGS_API_BASE=https://www.consumerfinance.gov/eregs-api/ ./runserver.sh` if you're running eRegs inside of cf.gov; `EREGS_API_BASE=https://www.consumerfinance.gov/eregs-api/ python manage.py runserver` if you're running it standalone).
3. Pop on over to eRegs at http://localhost:8000/eregulations/ and go to a reg that has updates in progress. Reg B (1002) is a good candidate since it has every page type that the new alert will appear on.
4. Verify that the update-in-progress alert appears in the sidebar on every page type in the reg as shown in the screenshots below:
    - Regulation text
    - Appendicies
    - Interpretations
    - Section-by-section analysis (1002.4 has SxS if you need an example)
    - Diffs
    - Search results

## Screenshots

Reg with no SxS | Reg with SxS | Reg with definition | SxS | Diff | Search
--------------- | ------------ | ------------------- | --- | ---- | ------
![reg-no-sxs](https://user-images.githubusercontent.com/1862695/36549581-1d6fddd2-17c1-11e8-9de6-6f577f100455.png) | ![reg-yes-sxs](https://user-images.githubusercontent.com/1862695/36549584-2116fd1c-17c1-11e8-8677-03025dcb47b2.png) | ![reg-def](https://user-images.githubusercontent.com/1862695/36549590-24da46d4-17c1-11e8-8c61-38f18c6b0405.png) | ![sxs](https://user-images.githubusercontent.com/1862695/36549598-2956b788-17c1-11e8-94b2-d3d6e7ecf761.png) | ![diff](https://user-images.githubusercontent.com/1862695/36549602-2d5cc49e-17c1-11e8-9371-29b209039b2b.png) | ![search](https://user-images.githubusercontent.com/1862695/36549610-314663e4-17c1-11e8-861a-8516050057a8.png)

## Notes

- As seen in the "reg with definition" screenshot above, definitions will appear on top of the alert. That's intentional but not ideal (always keeping the alert on top of definitions would have required too many changes for the scope of this PR).
- The alert doesn't consistently appear on the search results page, but I think that's a bug with the search results page template and not with the alert (the help module doesn't always appear either, even on production). Given that you'll still see the alert on any page you get to from the search results page, this is again intentional.