### PR TITLE
Bump requests version from 2.12.4 to 2.18.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'Django>=1.8,<1.9',
         'lxml==4.1.0',
-        'requests==2.12.4',
+        'requests==2.18.4',
     ],
     classifiers=[
         'Framework :: Django',


### PR DESCRIPTION
See https://github.com/cfpb/cfgov-refresh/pull/4059; this change bumps the version of requests required by this package from 2.12.4 to 2.18.4, to maintain compatibility with cfgov-refresh.

As this is a minor version bump, this shouldn't break any major functionality. All unit tests continue to pass.

FYI @acrewdson.